### PR TITLE
Add kernel configuration and CLI scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ipa_core/
   plugins.py  # Carga de entry points
 
 ### api/
-- cli.py: comandos ipa plugins y ipa run.
+- cli.py: comandos `ipa plugins` y `ipa run` basados en Typer.
 
 ### backends/
 - base.py: interfaz ASRBackend.transcribe_ipa(audio_path) -> str
@@ -55,6 +55,11 @@ flowchart TD
     J --> K["Reportes<br/>PER global · matriz de confusión · PER por clase"]
     K --> L["Salida<br/>JSON/CSV · gráficos · ejemplos de audio con marcas"]
 ```
+
+## Configuración del kernel
+
+Consulte [`docs/kernel.md`](docs/kernel.md) para la guía detallada sobre la
+configuración (`KernelConfig`), gestión de plugins y uso del CLI stub.
 
 ## Proximos pasos
 - Implementar backend ASR real (Whisper-IPA y/o Allosaurus).

--- a/config/ipa_kernel.yaml
+++ b/config/ipa_kernel.yaml
@@ -1,0 +1,6 @@
+# Configuración base del kernel IPA
+plugins:
+  asr_backend: null
+  textref: noop
+  comparator: noop
+  preprocessor:

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -1,0 +1,62 @@
+# Núcleo y configuración de plugins
+
+El **Kernel** de PronunciaPA actúa como orquestador de los plugins que
+componen el pipeline principal (ASR → TextRef → Comparator). Esta versión
+implementa un *stub* de ejecución que valida la configuración y carga los
+plugins registrados mediante *entry points* de Python.
+
+## KernelConfig
+
+La clase `KernelConfig` se define como un `dataclass` con los campos:
+
+| Campo         | Descripción                                             | Valor por defecto |
+|---------------|---------------------------------------------------------|-------------------|
+| `asr_backend` | Backend ASR que convierte audio a IPA (`ipa_core.backends.asr`) | `null`            |
+| `textref`     | Conversor de texto a IPA (`ipa_core.plugins.textref`)   | `noop`            |
+| `comparator`  | Comparador de cadenas IPA (`ipa_core.plugins.compare`)  | `noop`            |
+| `preprocessor`| Preprocesador opcional (`ipa_core.plugins.preprocess`)  | `None`            |
+
+La configuración puede declararse directamente en YAML usando un bloque
+`plugins` o en formato plano. Ejemplo:
+
+```yaml
+plugins:
+  asr_backend: null
+  textref: noop
+  comparator: noop
+  preprocessor: null
+```
+
+El método `KernelConfig.from_yaml` carga el archivo y valida que contenga un
+mapeo. Para inspeccionar la configuración efectiva se puede invocar
+`KernelConfig.to_mapping()`.
+
+## Gestión de plugins
+
+Los plugins se descubren mediante los *entry points* definidos en
+`pyproject.toml`. Los grupos actualmente soportados son:
+
+- `ipa_core.backends.asr` (alias CLI `asr`)
+- `ipa_core.plugins.textref` (alias CLI `textref`)
+- `ipa_core.plugins.compare` (alias CLI `comparator`)
+- `ipa_core.plugins.preprocess` (alias CLI `preprocessor`)
+
+La utilidad `ipa plugins list` muestra los plugins disponibles, permitiendo
+filtrar por grupo con `--group`.
+
+## Ejecución del pipeline (stub)
+
+El comando `ipa run` instancia el kernel usando el archivo de configuración y
+recorre el directorio de entrada indicado. Como aún no existe lógica de
+procesamiento fonético, la salida se limita a un reporte con la configuración
+activa y los archivos detectados. Para validar únicamente la configuración se
+puede usar `--dry-run`.
+
+Ejemplo:
+
+```bash
+ipa run --config config/ipa_kernel.yaml --input inputs/ --dry-run --show-config
+```
+
+Esta ejecución no procesa audio, pero garantiza que los plugins se cargan de
+forma correcta y que la configuración es válida.

--- a/ipa_core/kernel.py
+++ b/ipa_core/kernel.py
@@ -1,26 +1,220 @@
-﻿from dataclasses import dataclass
-from ipa_core.plugins import load_plugin
+"""Kernel orchestration for the IPA core pipeline."""
+from __future__ import annotations
 
-@dataclass
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    yaml = None
+
+from ipa_core.plugins import PLUGIN_GROUPS, load_plugin
+
+__all__ = ["Kernel", "KernelConfig"]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
 class KernelConfig:
-    asr: str = "null"
+    """Configuration data class for plugin selection.
+
+    Parameters
+    ----------
+    asr_backend:
+        Name of the ASR backend plugin (``ipa_core.backends.asr`` group).
+    textref:
+        Name of the text-to-IPA plugin (``ipa_core.plugins.textref`` group).
+    comparator:
+        Name of the comparator plugin (``ipa_core.plugins.compare`` group).
+    preprocessor:
+        Optional preprocessor plugin name (``ipa_core.plugins.preprocess`` group).
+    """
+
+    asr_backend: str = "null"
     textref: str = "noop"
     comparator: str = "noop"
+    preprocessor: str | None = None
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "KernelConfig":
+        """Create an instance from a dictionary-like object.
+
+        The expected structure is either a flat mapping with the fields of
+        :class:`KernelConfig` or a mapping containing a ``plugins`` section.
+        Any missing values are filled with the dataclass defaults.
+        """
+
+        if "plugins" in data:
+            plugins_cfg = data.get("plugins") or {}
+            if not isinstance(plugins_cfg, Mapping):
+                raise ValueError("La sección 'plugins' debe ser un mapeo")
+        else:
+            plugins_cfg = data
+
+        kwargs: dict[str, Any] = {}
+        for field in ("asr_backend", "textref", "comparator", "preprocessor"):
+            if field in plugins_cfg and plugins_cfg[field] is not None:
+                kwargs[field] = plugins_cfg[field]
+
+        return cls(**kwargs)
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> "KernelConfig":
+        """Load configuration from a YAML file."""
+
+        cfg_path = Path(path)
+        raw = cfg_path.read_text(encoding="utf-8") if cfg_path.exists() else ""
+        payload = _load_yaml(raw) if raw else {}
+        if payload is None:
+            payload = {}
+        if not isinstance(payload, Mapping):
+            raise ValueError("El archivo de configuración debe contener un mapeo")
+        return cls.from_mapping(payload)
+
+    def to_mapping(self) -> dict[str, Any]:
+        """Return a serialisable representation of the configuration."""
+
+        return {
+            "asr_backend": self.asr_backend,
+            "textref": self.textref,
+            "comparator": self.comparator,
+            "preprocessor": self.preprocessor,
+        }
+
 
 class Kernel:
+    """Instantiate and orchestrate the registered plugins."""
+
     def __init__(self, cfg: KernelConfig):
-        ASR = load_plugin("ipa_core.backends.asr", cfg.asr)
-        TXT = load_plugin("ipa_core.plugins.textref", cfg.textref)
-        CMP = load_plugin("ipa_core.plugins.compare", cfg.comparator)
-        self.asr = ASR()
-        self.textref = TXT()
-        self.cmp = CMP()
+        self.config = cfg
+        self.asr = self._instantiate("asr", cfg.asr_backend)
+        self.textref = self._instantiate("textref", cfg.textref)
+        self.comparator = self._instantiate("comparator", cfg.comparator)
+        self.preprocessor = (
+            self._instantiate("preprocessor", cfg.preprocessor)
+            if cfg.preprocessor
+            else None
+        )
 
-    def audio_to_ipa(self, audio_path: str) -> str:
-        return self.asr.transcribe_ipa(audio_path)
+    @staticmethod
+    def _resolve_group(group_key: str) -> str:
+        try:
+            return PLUGIN_GROUPS[group_key].entrypoint_group
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise ValueError(f"Grupo de plugins desconocido: {group_key}") from exc
 
-    def text_to_ipa(self, text: str, lang: str | None = None) -> str:
-        return self.textref.text_to_ipa(text, lang)
+    def _instantiate(self, group_key: str, plugin_name: str | None):
+        if not plugin_name:
+            return None
+        group = self._resolve_group(group_key)
+        plugin_cls = load_plugin(group, plugin_name)
+        return plugin_cls()
 
-    def compare(self, ref_ipa: str, hyp_ipa: str):
-        return self.cmp.compare(ref_ipa, hyp_ipa)
+    def run(self, input_dir: str | Path, dry_run: bool = False) -> dict[str, Any]:
+        """Execute the (stub) pipeline.
+
+        Returns a dictionary with diagnostic information so callers can
+        inspect which plugins were activated. The actual phonetic processing
+        will be implemented in future iterations.
+        """
+
+        input_path = Path(input_dir)
+        if not input_path.exists():
+            logger.warning(
+                "El directorio de entrada %s no existe; se continúa con lista vacía",
+                input_path,
+            )
+            files: list[str] = []
+        else:
+            files = sorted(p.name for p in input_path.iterdir() if p.is_file())
+
+        result = {
+            "input_dir": str(input_path),
+            "files": files,
+            "plugins": self.config.to_mapping(),
+            "dry_run": dry_run,
+        }
+
+        if dry_run:
+            logger.info("Ejecución en modo dry-run; no se procesa audio")
+            return result
+
+        logger.info(
+            "Kernel stub ejecutado con %d archivo(s) utilizando plugins %s",
+            len(files),
+            result["plugins"],
+        )
+        return result
+
+
+def _coerce_scalar(value: str) -> Any:
+    lowered = value.lower()
+    if lowered in {"", "null", "none", "~"}:
+        return None
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    return value
+
+
+def _load_yaml(raw: str) -> Mapping[str, Any] | None:
+    if yaml is not None:
+        return yaml.safe_load(raw)
+
+    result: dict[str, Any] = {}
+    stack: list[dict[str, Any]] = [result]
+    indents = [0]
+    last_keys = [None]
+
+    lines = raw.splitlines()
+    for line in lines:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+
+        indent = len(line) - len(line.lstrip(" "))
+        if indent % 2 != 0:
+            raise ValueError("Indentación inválida en YAML (se esperaban múltiplos de 2 espacios)")
+
+        while indent < indents[-1]:
+            stack.pop()
+            indents.pop()
+            last_keys.pop()
+
+        if indent > indents[-1]:
+            if indent != indents[-1] + 2:
+                raise ValueError("Incremento de indentación inválido en YAML simplificado")
+            parent = stack[-1]
+            pending_key = last_keys[-1]
+            if pending_key is None:
+                raise ValueError("No hay clave padre para anidar el bloque")
+            new_dict: dict[str, Any] = {}
+            parent[pending_key] = new_dict
+            stack.append(new_dict)
+            indents.append(indent)
+            last_keys.append(None)
+
+        current = stack[-1]
+        key, _, remainder = line.strip().partition(":")
+        key = key.strip()
+        remainder = remainder.strip()
+
+        if not remainder:
+            current[key] = None
+            last_keys[-1] = key
+            continue
+
+        current[key] = _coerce_scalar(remainder)
+        last_keys[-1] = key
+
+    return result

--- a/ipa_core/plugins.py
+++ b/ipa_core/plugins.py
@@ -1,10 +1,104 @@
-﻿from importlib import metadata
+"""Utilities for discovering and loading IPA Core plugins.
+
+This module provides a tiny abstraction over :mod:`importlib.metadata`
+entry points so that the rest of the codebase can reason about plugins
+in terms of logical groups (``asr_backend``, ``textref`` ...).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import metadata
+from typing import Iterable
+
+__all__ = [
+    "PLUGIN_GROUPS",
+    "PluginGroup",
+    "load_plugin",
+    "list_plugins",
+]
+
+
+@dataclass(frozen=True)
+class PluginGroup:
+    """Represents a logical group of plugins.
+
+    Attributes
+    ----------
+    name:
+        Human-friendly identifier used from the CLI (``asr``/``textref`` ...).
+    entrypoint_group:
+        Name of the entry-point group registered in ``pyproject.toml``.
+    description:
+        Short explanation used when rendering help messages.
+    """
+
+    name: str
+    entrypoint_group: str
+    description: str
+
+
+PLUGIN_GROUPS: dict[str, PluginGroup] = {
+    "asr": PluginGroup(
+        name="asr",
+        entrypoint_group="ipa_core.backends.asr",
+        description="Backends de reconocimiento de voz a IPA",
+    ),
+    "textref": PluginGroup(
+        name="textref",
+        entrypoint_group="ipa_core.plugins.textref",
+        description="Conversores de texto a IPA (referencia)",
+    ),
+    "comparator": PluginGroup(
+        name="comparator",
+        entrypoint_group="ipa_core.plugins.compare",
+        description="Comparadores de secuencias IPA",
+    ),
+    "preprocessor": PluginGroup(
+        name="preprocessor",
+        entrypoint_group="ipa_core.plugins.preprocess",
+        description="Preprocesadores de audio/texto previos al pipeline",
+    ),
+}
+
+
+def _iter_entry_points(group: str) -> Iterable[metadata.EntryPoint]:
+    """Iterate over entry points for ``group``.
+
+    A thin wrapper around :func:`importlib.metadata.entry_points` so the
+    behaviour can be stubbed easily during testing.
+    """
+
+    return metadata.entry_points().select(group=group)
+
 
 def load_plugin(group: str, name: str):
-    for ep in metadata.entry_points().select(group=group):
+    """Load a plugin identified by ``group`` and ``name``.
+
+    Parameters
+    ----------
+    group:
+        Entry-point group name (``ipa_core.backends.asr`` ...).
+    name:
+        Plugin name inside the group.
+
+    Returns
+    -------
+    Any
+        The object exposed by the entry point (usually a class).
+
+    Raises
+    ------
+    ValueError
+        If the plugin cannot be found within the requested group.
+    """
+
+    for ep in _iter_entry_points(group):
         if ep.name == name:
             return ep.load()
     raise ValueError(f"Plugin no encontrado: {group}::{name}")
 
+
 def list_plugins(group: str) -> list[str]:
-    return sorted(ep.name for ep in metadata.entry_points().select(group=group))
+    """Return the available plugin names for ``group`` sorted alphabetically."""
+
+    return sorted(ep.name for ep in _iter_entry_points(group))

--- a/ipa_core/tests/test_kernel.py
+++ b/ipa_core/tests/test_kernel.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import sys
+from importlib import metadata
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+
+from ipa_core.kernel import Kernel, KernelConfig
+from ipa_core.plugins import PLUGIN_GROUPS, list_plugins, load_plugin
+
+
+class DummyEntryPoints:
+    def __init__(self, entries: list[metadata.EntryPoint]):
+        self._entries = entries
+
+    def select(self, *, group: str):
+        return [ep for ep in self._entries if ep.group == group]
+
+
+@pytest.fixture(autouse=True)
+def cleanup_fake_module():
+    yield
+    sys.modules.pop("fake_plugin", None)
+
+
+def register_fake_plugin(monkeypatch, group: str, name: str, obj):
+    module = ModuleType("fake_plugin")
+    setattr(module, "Plugin", obj)
+    sys.modules["fake_plugin"] = module
+
+    ep = metadata.EntryPoint(name=name, value="fake_plugin:Plugin", group=group)
+    monkeypatch.setattr(
+        "ipa_core.plugins.metadata.entry_points",
+        lambda: DummyEntryPoints([ep]),
+    )
+    return ep
+
+
+def test_load_plugin_success(monkeypatch):
+    class Dummy:
+        pass
+
+    register_fake_plugin(monkeypatch, "ipa_core.backends.asr", "dummy", Dummy)
+
+    loaded = load_plugin("ipa_core.backends.asr", "dummy")
+    assert loaded is Dummy
+
+
+def test_list_plugins_sorted(monkeypatch):
+    class Dummy:
+        pass
+
+    ep1 = metadata.EntryPoint(name="b", value="fake_plugin:Plugin", group="grp")
+    ep2 = metadata.EntryPoint(name="a", value="fake_plugin:Plugin", group="grp")
+    monkeypatch.setattr(
+        "ipa_core.plugins.metadata.entry_points",
+        lambda: DummyEntryPoints([ep1, ep2]),
+    )
+
+    assert list_plugins("grp") == ["a", "b"]
+
+
+def test_load_plugin_missing(monkeypatch):
+    monkeypatch.setattr(
+        "ipa_core.plugins.metadata.entry_points",
+        lambda: DummyEntryPoints([]),
+    )
+
+    with pytest.raises(ValueError):
+        load_plugin("grp", "missing")
+
+
+def test_kernel_instantiation(monkeypatch, tmp_path: Path):
+    class DummyASR:
+        def __call__(self):
+            return self
+
+        def transcribe_ipa(self, path: str) -> str:  # pragma: no cover - stub
+            return f"ipa::{path}"
+
+    class DummyText:
+        def __call__(self):
+            return self
+
+        def text_to_ipa(self, text: str, lang: str | None = None) -> str:  # pragma: no cover - stub
+            return f"ipa::{text}::{lang}"
+
+    class DummyCmp:
+        def __call__(self):
+            return self
+
+        def compare(self, ref: str, hyp: str):  # pragma: no cover - stub
+            return (ref, hyp)
+
+    def fake_loader(group: str, name: str):
+        mapping = {
+            PLUGIN_GROUPS["asr"].entrypoint_group: DummyASR,
+            PLUGIN_GROUPS["textref"].entrypoint_group: DummyText,
+            PLUGIN_GROUPS["comparator"].entrypoint_group: DummyCmp,
+        }
+        return mapping[group]
+
+    monkeypatch.setattr("ipa_core.kernel.load_plugin", fake_loader)
+
+    cfg = KernelConfig(asr_backend="a", textref="b", comparator="c")
+    kernel = Kernel(cfg)
+    result = kernel.run(tmp_path, dry_run=True)
+
+    assert result["plugins"]["asr_backend"] == "a"
+    assert result["plugins"]["textref"] == "b"
+    assert result["plugins"]["comparator"] == "c"
+    assert result["dry_run"] is True
+
+
+def test_kernel_run_collects_files(monkeypatch, tmp_path: Path):
+    audio_file = tmp_path / "sample.wav"
+    audio_file.write_text("fake")
+
+    class DummyPlugin:
+        def __call__(self):
+            return self
+
+    monkeypatch.setattr(
+        "ipa_core.kernel.load_plugin",
+        lambda group, name: DummyPlugin,
+    )
+
+    cfg = KernelConfig(asr_backend="null", textref="noop", comparator="noop")
+    kernel = Kernel(cfg)
+    result = kernel.run(tmp_path, dry_run=False)
+
+    assert result["files"] == ["sample.wav"]
+    assert result["dry_run"] is False
+
+
+def test_kernel_config_from_yaml(tmp_path: Path):
+    yaml_content = """
+plugins:
+  asr_backend: foo
+  textref: bar
+  comparator: baz
+  preprocessor:
+"""
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml_content)
+
+    cfg = KernelConfig.from_yaml(cfg_path)
+
+    assert cfg.asr_backend == "foo"
+    assert cfg.textref == "bar"
+    assert cfg.comparator == "baz"
+    assert cfg.preprocessor is None
+
+
+def test_kernel_config_invalid_section():
+    with pytest.raises(ValueError):
+        KernelConfig.from_mapping({"plugins": "no-es-un-mapeo"})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-﻿[build-system]
+[build-system]
 requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 
@@ -7,7 +7,9 @@ name = "ipa-core"
 version = "0.0.1"
 description = "Microkernel IPA MVP (skeleton)"
 requires-python = ">=3.11"
-dependencies = ["typer[all]>=0.12"]
+dependencies = [
+    "typer[all]>=0.12",
+]
 
 [project.scripts]
 ipa = "ipa_core.api.cli:app"


### PR DESCRIPTION
## Summary
- define `KernelConfig` with YAML loading, plugin instantiation and stub pipeline execution
- enhance plugin discovery helpers and Typer CLI to expose `ipa plugins` and `ipa run`
- add kernel documentation, sample configuration and unit tests for plugin orchestration

## Testing
- pytest ipa_core/tests/test_kernel.py

------
https://chatgpt.com/codex/tasks/task_e_68ddbbc3fb00832a8091e0c4f886ba48