### PR TITLE
Add script to generate sample dataset audio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,9 @@ Desktop.ini
 # *.flac
 # *.ogg
 
+# Samples de prueba
+data/sample/*.wav
+
 # Modelos de ML grandes (si usas modelos pre-entrenados)
 # *.model
 # *.pkl

--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ flowchart TD
 Consulte [`docs/kernel.md`](docs/kernel.md) para la guía detallada sobre la
 configuración (`KernelConfig`), gestión de plugins y uso del CLI stub.
 
+## Datos de ejemplo
+
+El repositorio incluye un dataset mínimo en `data/sample/` con tres pares
+audio-texto pensado para validar el pipeline localmente. Los archivos WAV no se
+versionan; genéralos cuando los necesites con:
+
+```bash
+python scripts/generate_sample_dataset.py
+```
+
+La documentación del formato y los scripts auxiliares están descritos en
+[`docs/data.md`](docs/data.md).
+
 ## Proximos pasos
 - Implementar backend ASR real (Whisper-IPA y/o Allosaurus).
 - Integrar phonemizer/espeak en TextRef.

--- a/data/sample/metadata.csv
+++ b/data/sample/metadata.csv
@@ -1,0 +1,4 @@
+audio_path,text,lang
+sample_01.wav,Tono de referencia en 440 Hz,es
+sample_02.wav,Tono de prueba en 554 Hz aproximados,es
+sample_03.wav,Tono de cierre en 659 Hz aproximados,es

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,63 @@
+# Sample dataset
+
+Esta carpeta describe un dataset mínimo para validar el pipeline de extremo a
+extremo sin necesidad de descargar datos adicionales.
+
+## Estructura de directorios
+
+```
+data/
+└── sample/
+    ├── metadata.csv
+    └── *.wav  # archivos generados localmente
+```
+
+Los audios WAV no se versionan en el repositorio para evitar binarios en los
+commits. Puedes generarlos en cualquier momento con el script incluido en
+`scripts/generate_sample_dataset.py`.
+
+Cada archivo de audio es un tono sintético en formato WAV (PCM de 16 bits, 16
+kHz, mono) con una duración inferior a 3 segundos. Los tonos sirven únicamente
+como sustitutos ligeros de grabaciones reales para pruebas locales.
+
+## Formato de metadatos
+
+El archivo `metadata.csv` utiliza codificación UTF-8 y tiene las columnas:
+
+- `audio_path`: Ruta relativa al directorio `data/sample/` del archivo de audio.
+- `text`: Texto asociado al audio (en este ejemplo describe el tono).
+- `lang`: Código de idioma ISO 639-1.
+
+Ejemplo:
+
+```
+audio_path,text,lang
+sample_01.wav,Tono de referencia en 440 Hz,es
+```
+
+## Generación de audios
+
+1. Asegúrate de haber instalado las dependencias base del proyecto.
+2. Ejecuta:
+
+   ```bash
+   python scripts/generate_sample_dataset.py
+   ```
+
+   El script crea tonos senoidales que cumplen con las especificaciones
+   (16 kHz, 16-bit PCM). Usa `--overwrite` para regenerar los archivos si ya
+   existen.
+
+## Validación
+
+Para comprobar que el dataset cumple los requisitos básicos se incluye el
+script `scripts/validate_dataset.py`. Valida la estructura del CSV, la
+existencia de los audios y sus propiedades principales.
+
+```bash
+python scripts/validate_dataset.py data/sample/metadata.csv
+```
+
+Si falta algún audio el script emitirá un error indicando que ejecutes el
+script de generación. Cuando todo esté correcto el comando mostrará
+`Validation passed ✅`.

--- a/scripts/generate_sample_dataset.py
+++ b/scripts/generate_sample_dataset.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Generate synthetic WAV files for the sample dataset.
+
+This script reads ``data/sample/metadata.csv`` and generates short sine wave
+clips for each entry so that the validation pipeline can run without shipping
+binary assets in the repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import struct
+from pathlib import Path
+import wave
+
+# Default configuration for each audio file declared in the metadata. Frequencies
+# are chosen to roughly match the textual descriptions in ``metadata.csv``.
+TONE_CONFIG = {
+    "sample_01.wav": {"frequency": 440.0, "duration": 2.0},
+    "sample_02.wav": {"frequency": 554.37, "duration": 2.0},
+    "sample_03.wav": {"frequency": 659.25, "duration": 2.0},
+}
+
+SAMPLE_RATE = 16_000
+SAMPLE_WIDTH = 2  # bytes, PCM 16-bit
+AMPLITUDE = 0.3  # scale for the sine wave (-1.0..1.0)
+
+
+def _synthesize_tone(path: Path, frequency: float, duration: float, overwrite: bool) -> None:
+    if path.exists() and not overwrite:
+        print(f"[SKIP] {path.name} already exists (use --overwrite to regenerate)")
+        return
+
+    total_frames = int(duration * SAMPLE_RATE)
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(SAMPLE_WIDTH)
+        wav_file.setframerate(SAMPLE_RATE)
+
+        frames = bytearray()
+        for n in range(total_frames):
+            sample = math.sin(2 * math.pi * frequency * n / SAMPLE_RATE)
+            value = int(max(min(sample * AMPLITUDE, 1.0), -1.0) * 32767)
+            frames.extend(struct.pack("<h", value))
+
+        wav_file.writeframes(frames)
+
+    print(f"[OK] Generated {path.name} ({duration:.1f}s @ {frequency:.2f} Hz)")
+
+
+def _load_metadata(metadata_path: Path) -> list[str]:
+    with metadata_path.open("r", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        if not reader.fieldnames or "audio_path" not in reader.fieldnames:
+            raise ValueError("metadata is missing the required 'audio_path' column")
+        return [row["audio_path"].strip() for row in reader]
+
+
+def generate(metadata_path: Path, overwrite: bool) -> None:
+    audio_files = _load_metadata(metadata_path)
+    base_dir = metadata_path.parent
+
+    for relative_name in audio_files:
+        if not relative_name:
+            print("[WARN] Encountered empty audio_path entry; skipping")
+            continue
+
+        config = TONE_CONFIG.get(relative_name)
+        if config is None:
+            raise KeyError(
+                f"No tone configuration available for {relative_name}. "
+                "Please add an entry to TONE_CONFIG."
+            )
+
+        output_path = base_dir / relative_name
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        _synthesize_tone(
+            output_path,
+            frequency=config["frequency"],
+            duration=config["duration"],
+            overwrite=overwrite,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate WAV files for the sample dataset")
+    parser.add_argument(
+        "metadata",
+        type=Path,
+        nargs="?",
+        default=Path("data/sample/metadata.csv"),
+        help="Metadata CSV to read (defaults to data/sample/metadata.csv)",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Regenerate audio files even if they already exist",
+    )
+    args = parser.parse_args()
+
+    generate(args.metadata, overwrite=args.overwrite)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_dataset.py
+++ b/scripts/validate_dataset.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Validate sample dataset metadata and audio files.
+
+Usage:
+    python scripts/validate_dataset.py data/sample/metadata.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+import wave
+
+
+def validate(metadata_path: Path) -> int:
+    required_columns = {"audio_path", "text", "lang"}
+    errors = 0
+
+    with metadata_path.open("r", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        missing = required_columns - set(reader.fieldnames or [])
+        if missing:
+            print(f"[ERROR] Missing required columns: {', '.join(sorted(missing))}")
+            return 1
+
+        for idx, row in enumerate(reader, start=2):
+            audio_rel = row["audio_path"].strip()
+            text = row["text"].strip()
+            lang = row["lang"].strip()
+
+            if not audio_rel:
+                print(f"[ERROR] Row {idx}: empty audio_path")
+                errors += 1
+                continue
+
+            audio_path = (metadata_path.parent / audio_rel).resolve()
+            if not audio_path.exists():
+                print(f"[ERROR] Row {idx}: audio file not found at {audio_rel}")
+                print(
+                    "        Genera los audios con 'python scripts/generate_sample_dataset.py'"
+                )
+                errors += 1
+                continue
+
+            try:
+                with wave.open(str(audio_path), "rb") as wav_file:
+                    sample_width = wav_file.getsampwidth()
+                    frame_rate = wav_file.getframerate()
+                    n_frames = wav_file.getnframes()
+                    duration = n_frames / frame_rate if frame_rate else 0
+            except wave.Error as exc:  # pragma: no cover - diagnostic output
+                print(f"[ERROR] Row {idx}: cannot open WAV file ({exc})")
+                errors += 1
+                continue
+
+            if sample_width != 2:
+                print(
+                    f"[ERROR] Row {idx}: expected 16-bit PCM (2 bytes) but got {sample_width} bytes",
+                )
+                errors += 1
+
+            if frame_rate != 16000:
+                print(
+                    f"[WARNING] Row {idx}: expected 16000 Hz sample rate but got {frame_rate} Hz",
+                )
+
+            if duration > 30:
+                print(
+                    f"[ERROR] Row {idx}: duration {duration:.2f}s exceeds 30s limit",
+                )
+                errors += 1
+
+            if not text:
+                print(f"[ERROR] Row {idx}: empty text field")
+                errors += 1
+
+            if not lang:
+                print(f"[ERROR] Row {idx}: empty lang field")
+                errors += 1
+
+    if errors == 0:
+        print("Validation passed ✅")
+    else:
+        print(f"Validation finished with {errors} error(s)")
+    return 0 if errors == 0 else 1
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate dataset metadata and audio files")
+    parser.add_argument(
+        "metadata",
+        type=Path,
+        help="Path to metadata CSV file (e.g., data/sample/metadata.csv)",
+    )
+    args = parser.parse_args()
+    exit(validate(args.metadata))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- remove the committed sample WAV fixtures and document generating them locally
- add a utility that synthesizes the metadata-defined tones so the dataset stays reproducible
- hint in the validation script about regenerating audio when files are missing

## Testing
- python scripts/generate_sample_dataset.py
- python scripts/validate_dataset.py data/sample/metadata.csv

------
https://chatgpt.com/codex/tasks/task_e_68ddbfa8fc5c832a9e337cb5eea1d72b