### PR TITLE
Implement Whisper IPA backend

### DIFF
--- a/docs/whisper_backend.md
+++ b/docs/whisper_backend.md
@@ -1,0 +1,46 @@
+# Backend Whisper-IPA
+
+El backend ``whisper-ipa`` integra el checkpoint público
+`neurlang/ipa-whisper-base` disponible en Hugging Face Hub. El modelo está
+ajustado para producir símbolos IPA directamente desde audio en castellano e
+inglés, cubriendo la etapa E del pipeline.
+
+## Requisitos
+
+1. **Dependencias**: asegúrate de instalar las dependencias opcionales
+   indicadas en ``pyproject.toml`` (`torch`, `transformers`).
+2. **Token de Hugging Face**: si el modelo requiere autenticación, ejecuta
+   `huggingface-cli login` y define `HF_HOME` si deseas controlar la ruta de
+   cache. Para repositorios públicos no es necesario el token.
+3. **Descarga inicial**: la primera ejecución descargará ~150 MB. Puedes
+   precachear manualmente con:
+
+   ```bash
+   python - <<'PY'
+   from transformers import pipeline
+   pipeline("automatic-speech-recognition", model="neurlang/ipa-whisper-base")
+   PY
+   ```
+
+## Uso
+
+Una vez instalado, el backend queda registrado como plugin ASR. Puede
+invocarse desde el CLI para verificar la instalación:
+
+```bash
+python -m ipa_core.api.cli plugins list --group asr
+```
+
+Para transcribir un archivo directamente desde Python:
+
+```python
+from ipa_core.backends.whisper_ipa import WhisperIPABackend
+
+backend = WhisperIPABackend()
+ipa = backend.transcribe_ipa("audio.wav")
+print(ipa)
+```
+
+La clase se encarga de normalizar el audio (mono, 16 kHz) y de solicitar al
+pipeline una salida IPA. Si la transcripción es vacía o el archivo no existe,
+se lanzará una excepción descriptiva.

--- a/ipa_core/backends/README.md
+++ b/ipa_core/backends/README.md
@@ -5,7 +5,7 @@ Paquete con implementaciones que convierten audio a secuencias IPA.
 ## Estructura
 - base.ASRBackend: clase abstracta con el contrato transcribe_ipa.
 - null_backend.NullASRBackend: stub que devuelve una cadena fija para pruebas.
-- whisper_ipa.WhisperIPABackend: plantilla para integrar un modelo Whisper orientado a IPA.
+- whisper_ipa.WhisperIPABackend: backend real basado en Hugging Face Whisper (salida IPA).
 
 ## Arquitectura de referencia
 - Emplear una CNN (pre-entrenada o a entrenar) para extraer embeddings acusticos robustos del audio crudo.

--- a/ipa_core/backends/tests/test_whisper_backend.py
+++ b/ipa_core/backends/tests/test_whisper_backend.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import math
+import wave
+
+import sys
+from array import array
+from importlib import metadata
+from pathlib import Path
+from typer.testing import CliRunner
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from ipa_core.api.cli import app
+from ipa_core.backends.whisper_ipa import WhisperIPABackend
+from ipa_core.plugins import PLUGIN_GROUPS
+
+
+class DummyEntryPoints:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def select(self, *, group: str):
+        return [ep for ep in self._entries if ep.group == group]
+
+
+def _write_wav(path: Path, samples: list[float], sample_rate: int) -> None:
+    clipped = [max(-1.0, min(1.0, value)) for value in samples]
+    int_samples = array("h", (int(round(value * 32767.0)) for value in clipped))
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(int_samples.tobytes())
+
+
+def test_transcribe_ipa_invoca_pipeline(tmp_path: Path):
+    calls = {}
+
+    def fake_pipeline(task, **kwargs):
+        assert task == "automatic-speech-recognition"
+        calls["pipeline_kwargs"] = kwargs
+
+        def run(audio, sampling_rate, **call_kwargs):
+            calls["audio"] = audio
+            calls["sampling_rate"] = sampling_rate
+            calls["call_kwargs"] = call_kwargs
+            return {"text": "t͡sa"}
+
+        return run
+
+    backend = WhisperIPABackend(model_name="dummy-model", pipeline_factory=fake_pipeline)
+
+    audio_path = tmp_path / "sample.wav"
+    samples = [math.sin(2 * math.pi * 440 * (i / 22_050)) for i in range(2_205)]
+    _write_wav(audio_path, samples, sample_rate=22_050)
+
+    ipa = backend.transcribe_ipa(str(audio_path))
+
+    assert ipa == "t͡sa"
+    assert calls["sampling_rate"] == backend.target_sample_rate
+    max_abs = max(abs(value) for value in calls["audio"])
+    assert abs(max_abs - 1.0) < 1e-3
+    assert calls["call_kwargs"]["generate_kwargs"]["task"] == "transcribe"
+
+
+def test_cli_lists_whisper_backend(monkeypatch):
+    ep = metadata.EntryPoint(
+        name="whisper-ipa",
+        value="fake:Plugin",
+        group=PLUGIN_GROUPS["asr"].entrypoint_group,
+    )
+
+    monkeypatch.setattr(
+        "ipa_core.plugins.metadata.entry_points",
+        lambda: DummyEntryPoints([ep]),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["plugins", "list", "--group", "asr"])
+
+    assert result.exit_code == 0
+    assert "whisper-ipa" in result.stdout

--- a/ipa_core/backends/whisper_ipa.py
+++ b/ipa_core/backends/whisper_ipa.py
@@ -1,13 +1,149 @@
-﻿# Placeholder para backend Whisper-IPA (Transformers)
-# Implementar después: cargar pipeline y devolver IPA real.
+"""Backend ASR basado en Whisper con salida IPA."""
+
+from __future__ import annotations
+
+import audioop
+import wave
+from array import array
+from pathlib import Path
+from typing import Callable, Dict, Optional
+
 from ipa_core.backends.base import ASRBackend
 
+PipelineFactory = Callable[..., Callable[..., Dict[str, str]]]
+
+
 class WhisperIPABackend(ASRBackend):
+    """Convierte audio a IPA utilizando un modelo Whisper afinado."""
+
     name = "whisper-ipa"
+    target_sample_rate = 16_000
 
-    def __init__(self, model_name: str = "neurlang/ipa-whisper-base"):
+    def __init__(
+        self,
+        model_name: str = "neurlang/ipa-whisper-base",
+        *,
+        device: int | str | None = None,
+        pipeline_factory: PipelineFactory | None = None,
+        generate_kwargs: Optional[dict] = None,
+        chunk_length_s: float = 30.0,
+    ) -> None:
+        """Inicializa el backend cargando el pipeline de Transformers."""
+
+        if pipeline_factory is None:
+            from transformers import pipeline as hf_pipeline  # type: ignore
+
+            pipeline_factory = hf_pipeline
+
         self.model_name = model_name
-        # TODO: inicializar pipeline HF aquí
+        self.device = device
+        self.generate_kwargs = generate_kwargs or {"task": "transcribe"}
+        self.chunk_length_s = chunk_length_s
+        self._pipeline_factory = pipeline_factory
+        self._pipeline = self._create_pipeline()
 
+    # ------------------------------------------------------------------
+    # Audio helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _load_wave(path: Path) -> tuple[bytes, int, int]:
+        with wave.open(str(path), "rb") as wav_file:
+            sample_rate = wav_file.getframerate()
+            sample_width = wav_file.getsampwidth()
+            channels = wav_file.getnchannels()
+            frames = wav_file.readframes(wav_file.getnframes())
+
+        if channels > 1:
+            frames = audioop.tomono(frames, sample_width, 0.5, 0.5)
+
+        return frames, sample_rate, sample_width
+
+    @classmethod
+    def _resample_bytes(cls, frames: bytes, sample_width: int, orig_sr: int) -> tuple[bytes, int]:
+        if orig_sr == cls.target_sample_rate:
+            return frames, sample_width
+
+        resampled, _ = audioop.ratecv(
+            frames,
+            sample_width,
+            1,
+            orig_sr,
+            cls.target_sample_rate,
+            None,
+        )
+        return resampled, sample_width
+
+    @staticmethod
+    def _bytes_to_float(frames: bytes, sample_width: int) -> list[float]:
+        if sample_width not in (1, 2, 4):
+            frames = audioop.lin2lin(frames, sample_width, 2)
+            sample_width = 2
+
+        if sample_width == 1:
+            fmt = "b"
+            scale = float(2**7)
+        elif sample_width == 2:
+            fmt = "h"
+            scale = float(2**15)
+        else:
+            fmt = "i"
+            scale = float(2**31)
+
+        samples = array(fmt)
+        samples.frombytes(frames)
+        return [sample / scale for sample in samples]
+
+    @staticmethod
+    def _normalize(samples: list[float]) -> list[float]:
+        peak = max((abs(value) for value in samples), default=0.0)
+        if peak == 0.0:
+            return samples
+        return [value / peak for value in samples]
+
+    # ------------------------------------------------------------------
+    # Pipeline helpers
+    # ------------------------------------------------------------------
+    def _create_pipeline(self):
+        kwargs: dict = {
+            "model": self.model_name,
+            "chunk_length_s": self.chunk_length_s,
+            "return_timestamps": False,
+        }
+        if self.device is not None:
+            kwargs["device"] = self.device
+
+        pipe = self._pipeline_factory("automatic-speech-recognition", **kwargs)
+
+        model_wrapper = getattr(pipe, "model", None)
+        if model_wrapper is not None and hasattr(model_wrapper.config, "forced_decoder_ids"):
+            model_wrapper.config.forced_decoder_ids = None
+        if model_wrapper is not None and hasattr(model_wrapper.config, "suppress_tokens"):
+            model_wrapper.config.suppress_tokens = []
+
+        return pipe
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
     def transcribe_ipa(self, audio_path: str) -> str:
-        raise NotImplementedError("Pendiente implementar backend Whisper-IPA")
+        audio_file = Path(audio_path)
+        if not audio_file.exists():
+            raise FileNotFoundError(f"No se encontró el archivo de audio: {audio_path}")
+
+        frames, sr, sample_width = self._load_wave(audio_file)
+        frames, sample_width = self._resample_bytes(frames, sample_width, sr)
+        samples = self._bytes_to_float(frames, sample_width)
+        samples = self._normalize(samples)
+
+        call_kwargs = {"sampling_rate": self.target_sample_rate}
+        if self.generate_kwargs:
+            call_kwargs["generate_kwargs"] = self.generate_kwargs
+
+        result = self._pipeline(samples, **call_kwargs)
+        if not isinstance(result, dict) or "text" not in result:
+            raise RuntimeError("El pipeline Whisper devolvió una respuesta inesperada")
+
+        text = result["text"].strip()
+        if not text:
+            raise RuntimeError("El backend Whisper-IPA devolvió una transcripción vacía")
+        return text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ description = "Microkernel IPA MVP (skeleton)"
 requires-python = ">=3.11"
 dependencies = [
     "typer[all]>=0.12",
+    "transformers>=4.37",
+    "torch>=2.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- replace the Whisper backend stub with a functional implementation that normalizes mono audio, resamples to 16 kHz and invokes a Hugging Face pipeline for IPA output
- add unit tests that exercise the backend with synthetic audio and validate the CLI plugin listing wiring
- document setup instructions for the Whisper backend and declare the required torch/transformers dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddc2a9f8f4832a833f25712934ccd5