### PR TITLE
Add Levenshtein comparator with PER metrics

### DIFF
--- a/ipa_core/compare/README.md
+++ b/ipa_core/compare/README.md
@@ -4,7 +4,8 @@ Paquete responsable de calcular metrica y operaciones entre secuencias IPA.
 
 ## Componentes
 - base.Comparator: interfaz abstracta que define compare(ref_ipa, hyp_ipa) y retorna CompareResult.
-- base.CompareResult: dataclass con PER y lista de operaciones (op, ref, hyp).
+- base.CompareResult: dataclass con PER, totales (matches, sustituciones, inserciones, borrados) y operaciones alineadas.
+- levenshtein.LevenshteinComparator: implementación Needleman-Wunsch/Levenshtein con métricas globales y por fonema.
 - noop.NoopComparator: stub que devuelve PER 0 sin analizar entradas.
 
 ## Arquitectura de referencia
@@ -21,6 +22,15 @@ Paquete responsable de calcular metrica y operaciones entre secuencias IPA.
 - Mantener determinismo: mismas entradas deben producir siempre el mismo PER.
 - Perfilar rendimiento: comparaciones largas pueden requerir algoritmos optimizados.
 - Separar tokenizacion y metrica para reutilizar logica entre comparadores.
+
+## Formato de resultados
+
+`CompareResult` expone:
+
+- `per`: Phone Error Rate global calculado como `(sustituciones + inserciones + borrados) / total_ref_tokens`.
+- `ops`: lista ordenada de tuplas `(operacion, ref_token, hyp_token)` donde operación ∈ {`match`, `substitution`, `insertion`, `deletion`}.
+- `total_ref_tokens`, `matches`, `substitutions`, `insertions`, `deletions`: totales agregados.
+- `per_class`: diccionario `{token: PhonemeStats}` con los conteos por fonema (inserciones se registran con clave `+<token>`).
 
 ## Registro como plugin
 Declare la clase en pyproject.toml dentro del grupo ipa_core.plugins.compare para que el kernel pueda descubrirla.

--- a/ipa_core/compare/__init__.py
+++ b/ipa_core/compare/__init__.py
@@ -1,1 +1,11 @@
-﻿# Paquete de comparación IPA vs IPA
+"""Paquete de comparación IPA vs IPA."""
+
+from .base import CompareResult, Comparator, PhonemeStats
+from .levenshtein import LevenshteinComparator
+
+__all__ = [
+    "Comparator",
+    "CompareResult",
+    "PhonemeStats",
+    "LevenshteinComparator",
+]

--- a/ipa_core/compare/base.py
+++ b/ipa_core/compare/base.py
@@ -1,11 +1,37 @@
-﻿from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import List, Tuple
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+AlignmentOp = Tuple[str, str, str]
+
+
+@dataclass
+class PhonemeStats:
+    """Resumen de métricas por fonema."""
+
+    matches: int = 0
+    substitutions: int = 0
+    deletions: int = 0
+    insertions: int = 0
+
+    @property
+    def errors(self) -> int:
+        return self.substitutions + self.deletions + self.insertions
+
 
 @dataclass
 class CompareResult:
+    """Resultado de la comparación entre dos secuencias IPA."""
+
     per: float
-    ops: List[Tuple[str, str, str]]  # (op, ref_tok, hyp_tok)
+    ops: List[AlignmentOp]
+    total_ref_tokens: int
+    matches: int
+    substitutions: int
+    insertions: int
+    deletions: int
+    per_class: Dict[str, PhonemeStats] = field(default_factory=dict)
+
 
 class Comparator(ABC):
     @abstractmethod

--- a/ipa_core/compare/levenshtein.py
+++ b/ipa_core/compare/levenshtein.py
@@ -1,0 +1,145 @@
+"""Comparador basado en algoritmo de Levenshtein/Needleman-Wunsch."""
+
+from typing import Callable, Dict, List, Optional
+
+from .base import AlignmentOp, CompareResult, Comparator, PhonemeStats
+
+Operation = str
+
+MATCH: Operation = "match"
+SUBSTITUTION: Operation = "substitution"
+INSERTION: Operation = "insertion"
+DELETION: Operation = "deletion"
+
+
+def _default_token_normalizer(token: str) -> str:
+    """Normaliza tokens IPA removiendo espacios extra."""
+
+    return token.strip()
+
+
+def _default_tokenizer(text: str) -> List[str]:
+    if text is None:
+        return []
+    tokens = [t for t in text.strip().split() if t]
+    return [_default_token_normalizer(t) for t in tokens]
+
+
+class LevenshteinComparator(Comparator):
+    """Implementación del comparador clásico de distancia de edición."""
+
+    def __init__(
+        self,
+        tokenizer: Optional[Callable[[str], List[str]]] = None,
+        normalizer: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        self._tokenizer = tokenizer or _default_tokenizer
+        self._normalizer = normalizer or _default_token_normalizer
+
+    def compare(self, ref_ipa: str, hyp_ipa: str) -> CompareResult:
+        ref_tokens = [self._normalizer(tok) for tok in self._tokenizer(ref_ipa)]
+        hyp_tokens = [self._normalizer(tok) for tok in self._tokenizer(hyp_ipa)]
+
+        ops = self._align(ref_tokens, hyp_tokens)
+        return self._build_result(ref_tokens, ops)
+
+    def _align(self, ref_tokens: List[str], hyp_tokens: List[str]) -> List[AlignmentOp]:
+        n = len(ref_tokens)
+        m = len(hyp_tokens)
+        dp: List[List[int]] = [[0] * (m + 1) for _ in range(n + 1)]
+        backtrack: List[List[Optional[str]]] = [[None] * (m + 1) for _ in range(n + 1)]
+
+        for i in range(1, n + 1):
+            dp[i][0] = i
+            backtrack[i][0] = DELETION
+        for j in range(1, m + 1):
+            dp[0][j] = j
+            backtrack[0][j] = INSERTION
+
+        for i in range(1, n + 1):
+            for j in range(1, m + 1):
+                if ref_tokens[i - 1] == hyp_tokens[j - 1]:
+                    cost_sub = dp[i - 1][j - 1]
+                else:
+                    cost_sub = dp[i - 1][j - 1] + 1
+                cost_del = dp[i - 1][j] + 1
+                cost_ins = dp[i][j - 1] + 1
+
+                min_cost = min(cost_sub, cost_del, cost_ins)
+                dp[i][j] = min_cost
+                if min_cost == cost_sub:
+                    backtrack[i][j] = MATCH if ref_tokens[i - 1] == hyp_tokens[j - 1] else SUBSTITUTION
+                elif min_cost == cost_del:
+                    backtrack[i][j] = DELETION
+                else:
+                    backtrack[i][j] = INSERTION
+
+        ops: List[AlignmentOp] = []
+        i, j = n, m
+        while i > 0 or j > 0:
+            action = backtrack[i][j]
+            if action in (MATCH, SUBSTITUTION):
+                ref_tok = ref_tokens[i - 1] if i > 0 else ""
+                hyp_tok = hyp_tokens[j - 1] if j > 0 else ""
+                ops.append((action, ref_tok, hyp_tok))
+                i -= 1
+                j -= 1
+            elif action == DELETION:
+                ref_tok = ref_tokens[i - 1] if i > 0 else ""
+                ops.append((DELETION, ref_tok, ""))
+                i -= 1
+            elif action == INSERTION:
+                hyp_tok = hyp_tokens[j - 1] if j > 0 else ""
+                ops.append((INSERTION, "", hyp_tok))
+                j -= 1
+            else:
+                # Only possible when both i and j are zero.
+                break
+
+        ops.reverse()
+        return ops
+
+    def _build_result(self, ref_tokens: List[str], ops: List[AlignmentOp]) -> CompareResult:
+        total_ref = len(ref_tokens)
+        matches = sum(1 for op, _, _ in ops if op == MATCH)
+        substitutions = sum(1 for op, _, _ in ops if op == SUBSTITUTION)
+        insertions = sum(1 for op, _, _ in ops if op == INSERTION)
+        deletions = sum(1 for op, _, _ in ops if op == DELETION)
+
+        per = 0.0 if total_ref == 0 else (substitutions + insertions + deletions) / total_ref
+
+        per_class: Dict[str, PhonemeStats] = {}
+        for op, ref_tok, hyp_tok in ops:
+            if op == INSERTION:
+                key = f"+{hyp_tok}" if hyp_tok else "<ins>"
+            else:
+                key = ref_tok if ref_tok else "<eps>"
+            stats = per_class.setdefault(key, PhonemeStats())
+            if op == MATCH:
+                stats.matches += 1
+            elif op == SUBSTITUTION:
+                stats.substitutions += 1
+            elif op == INSERTION:
+                stats.insertions += 1
+            elif op == DELETION:
+                stats.deletions += 1
+
+        return CompareResult(
+            per=per,
+            ops=ops,
+            total_ref_tokens=total_ref,
+            matches=matches,
+            substitutions=substitutions,
+            insertions=insertions,
+            deletions=deletions,
+            per_class=per_class,
+        )
+
+
+__all__ = [
+    "LevenshteinComparator",
+    "MATCH",
+    "SUBSTITUTION",
+    "INSERTION",
+    "DELETION",
+]

--- a/ipa_core/compare/noop.py
+++ b/ipa_core/compare/noop.py
@@ -1,6 +1,16 @@
-﻿from ipa_core.compare.base import Comparator, CompareResult
+from ipa_core.compare.base import Comparator, CompareResult
+
 
 class NoopComparator(Comparator):
     def compare(self, ref_ipa: str, hyp_ipa: str) -> CompareResult:
         # Stub: sin cálculo, PER=0 y sin ops
-        return CompareResult(per=0.0, ops=[])
+        return CompareResult(
+            per=0.0,
+            ops=[],
+            total_ref_tokens=0,
+            matches=0,
+            substitutions=0,
+            insertions=0,
+            deletions=0,
+            per_class={},
+        )

--- a/ipa_core/compare/tests/test_levenshtein.py
+++ b/ipa_core/compare/tests/test_levenshtein.py
@@ -1,0 +1,70 @@
+import math
+
+import pytest
+
+from ..base import CompareResult
+from ..levenshtein import INSERTION, MATCH, SUBSTITUTION, LevenshteinComparator
+
+
+@pytest.fixture()
+def comparator() -> LevenshteinComparator:
+    return LevenshteinComparator()
+
+
+def test_exact_match(comparator: LevenshteinComparator) -> None:
+    result = comparator.compare("p a", "p a")
+
+    assert math.isclose(result.per, 0.0)
+    assert result.total_ref_tokens == 2
+    assert result.matches == 2
+    assert result.substitutions == 0
+    assert result.insertions == 0
+    assert result.deletions == 0
+    assert result.ops == [
+        (MATCH, "p", "p"),
+        (MATCH, "a", "a"),
+    ]
+    assert result.per_class["p"].matches == 1
+    assert result.per_class["a"].matches == 1
+
+
+def test_single_substitution(comparator: LevenshteinComparator) -> None:
+    result = comparator.compare("p a", "p o")
+
+    assert math.isclose(result.per, 0.5)
+    assert result.total_ref_tokens == 2
+    assert result.matches == 1
+    assert result.substitutions == 1
+    assert result.ops == [
+        (MATCH, "p", "p"),
+        (SUBSTITUTION, "a", "o"),
+    ]
+    assert result.per_class["a"].substitutions == 1
+    assert "p" in result.per_class and result.per_class["p"].matches == 1
+
+
+def test_insertion(comparator: LevenshteinComparator) -> None:
+    result = comparator.compare("p a", "p a o")
+
+    assert math.isclose(result.per, 0.5)
+    assert result.total_ref_tokens == 2
+    assert result.insertions == 1
+    assert result.ops[-1] == (INSERTION, "", "o")
+    assert result.per_class["+o"].insertions == 1
+
+
+def test_empty_reference(comparator: LevenshteinComparator) -> None:
+    result = comparator.compare("", "p a")
+
+    assert result.total_ref_tokens == 0
+    assert math.isclose(result.per, 0.0)
+    assert result.insertions == 2
+    assert result.ops == [
+        (INSERTION, "", "p"),
+        (INSERTION, "", "a"),
+    ]
+
+
+def test_compare_result_repr(comparator: LevenshteinComparator) -> None:
+    result = comparator.compare("p", "p")
+    assert isinstance(result, CompareResult)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,4 @@ phonemizer = "ipa_core.textref.phonemizer_ref:PhonemizerTextRef"
 
 [project.entry-points."ipa_core.plugins.compare"]
 noop = "ipa_core.compare.noop:NoopComparator"
+levenshtein = "ipa_core.compare.levenshtein:LevenshteinComparator"


### PR DESCRIPTION
## Summary
- extend the compare package core dataclasses to expose per-class metrics
- implement a Levenshtein-based comparator with PER calculations and plugin registration
- cover the new behavior with unit tests for matches, substitutions, insertions, and empty references

## Testing
- pytest ipa_core/compare/tests/test_levenshtein.py

------
https://chatgpt.com/codex/tasks/task_e_68ddcf53ec58832a8cc96513e662917a