### PR TITLE
Implement CLI run orchestration and reporting pipeline

### DIFF
--- a/configs/local.yaml
+++ b/configs/local.yaml
@@ -1,0 +1,4 @@
+plugins:
+  asr_backend: null
+  textref: noop
+  comparator: levenshtein

--- a/ipa_core/api/cli.py
+++ b/ipa_core/api/cli.py
@@ -1,6 +1,9 @@
 """Typer-based command line interface for the IPA core kernel."""
 from __future__ import annotations
 
+import csv
+import json
+import logging
 from pathlib import Path
 from typing import Optional
 
@@ -12,6 +15,8 @@ from ipa_core.plugins import PLUGIN_GROUPS, list_plugins
 app = typer.Typer(help="CLI del microkernel IPA")
 plugins_app = typer.Typer(help="Gestión de plugins registrados")
 app.add_typer(plugins_app, name="plugins")
+
+logger = logging.getLogger(__name__)
 
 
 def _echo_plugins(group_key: str) -> None:
@@ -45,7 +50,7 @@ def list_plugins_cmd(
         _echo_plugins(group_key)
 
 
-@app.command(help="Ejecutar el pipeline principal (stub)")
+@app.command(help="Ejecutar el pipeline principal")
 def run(
     config: Path = typer.Option(
         ...,
@@ -57,12 +62,13 @@ def run(
         ...,
         "--input",
         "-i",
-        help="Directorio con los archivos de entrada a procesar",
+        help="Archivo CSV con metadata de los audios y textos de referencia",
     ),
-    dry_run: bool = typer.Option(
-        False,
-        "--dry-run",
-        help="Validar configuración y listar archivos sin ejecutar el pipeline",
+    output: Path = typer.Option(
+        ...,
+        "--output",
+        "-o",
+        help="Directorio donde se almacenarán los reportes generados",
     ),
     show_config: bool = typer.Option(
         False,
@@ -70,7 +76,14 @@ def run(
         help="Mostrar la configuración efectiva cargada",
     ),
 ) -> None:
-    cfg = KernelConfig.from_yaml(config)
+    logging.basicConfig(level=logging.INFO)
+
+    try:
+        cfg = KernelConfig.from_yaml(config)
+    except Exception as exc:  # pragma: no cover - errores de configuración
+        typer.secho(f"Error al cargar configuración: {exc}", fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
     kernel = Kernel(cfg)
 
     if show_config:
@@ -78,17 +91,30 @@ def run(
         for key, value in cfg.to_mapping().items():
             typer.echo(f"- {key}: {value}")
 
-    result = kernel.run(input, dry_run=dry_run)
+    try:
+        report = kernel.run(input)
+    except Exception as exc:  # pragma: no cover - propagación controlada
+        logger.exception("Error al ejecutar el kernel")
+        typer.secho(f"Error al ejecutar el pipeline: {exc}", fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
 
+    output.mkdir(parents=True, exist_ok=True)
+    json_path = output / "report.json"
+    csv_path = output / "report.csv"
+
+    _write_json(json_path, report)
+    _write_csv(csv_path, report.get("detalles", []))
+
+    typer.echo(f"Reporte JSON generado en: {json_path}")
+    typer.echo(f"Reporte CSV generado en: {csv_path}")
+    summary = report.get("summary", {})
     typer.echo(
-        f"Pipeline stub ejecutado en '{result['input_dir']}' "
-        f"({len(result['files'])} archivos, dry_run={result['dry_run']})"
+        "Resumen: {procesados} procesados, {con_error} con error, PER global={per:.4f}".format(
+            procesados=summary.get("procesados", 0),
+            con_error=summary.get("con_error", 0),
+            per=report.get("per_global", 0.0),
+        )
     )
-
-    if result["files"]:
-        typer.echo("Archivos detectados:")
-        for file_name in result["files"]:
-            typer.echo(f"  - {file_name}")
 
 
 @app.command(help="Mostrar plugins disponibles (alias rápido)")
@@ -96,3 +122,31 @@ def plugins() -> None:
     """Convenience alias matching la API anterior."""
 
     list_plugins_cmd()
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _write_csv(path: Path, details: list[dict]) -> None:
+    fieldnames = [
+        "index",
+        "audio_path",
+        "text",
+        "lang",
+        "ref_ipa",
+        "hyp_ipa",
+        "per",
+        "matches",
+        "substitutions",
+        "insertions",
+        "deletions",
+        "total_ref_tokens",
+        "error",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in details:
+            serialised = {key: row.get(key, "") for key in fieldnames}
+            writer.writerow(serialised)

--- a/ipa_core/kernel.py
+++ b/ipa_core/kernel.py
@@ -1,16 +1,18 @@
 """Kernel orchestration for the IPA core pipeline."""
 from __future__ import annotations
 
+import csv
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
 try:  # pragma: no cover - optional dependency
     import yaml  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     yaml = None
 
+from ipa_core.compare.base import CompareResult, PhonemeStats
 from ipa_core.plugins import PLUGIN_GROUPS, load_plugin
 
 __all__ = ["Kernel", "KernelConfig"]
@@ -86,6 +88,15 @@ class KernelConfig:
         }
 
 
+@dataclass(slots=True)
+class _Sample:
+    index: int
+    audio_original: str
+    audio_path: Path
+    text: str
+    lang: str | None
+
+
 class Kernel:
     """Instantiate and orchestrate the registered plugins."""
 
@@ -114,41 +125,87 @@ class Kernel:
         plugin_cls = load_plugin(group, plugin_name)
         return plugin_cls()
 
-    def run(self, input_dir: str | Path, dry_run: bool = False) -> dict[str, Any]:
-        """Execute the (stub) pipeline.
+    def run(self, metadata_path: str | Path) -> dict[str, Any]:
+        """Execute the IPA pipeline over the provided metadata file."""
 
-        Returns a dictionary with diagnostic information so callers can
-        inspect which plugins were activated. The actual phonetic processing
-        will be implemented in future iterations.
-        """
-
-        input_path = Path(input_dir)
-        if not input_path.exists():
-            logger.warning(
-                "El directorio de entrada %s no existe; se continúa con lista vacía",
-                input_path,
+        if self.asr is None or self.textref is None or self.comparator is None:
+            raise RuntimeError(
+                "Se requieren plugins configurados para ASR, TextRef y Comparator"
             )
-            files: list[str] = []
-        else:
-            files = sorted(p.name for p in input_path.iterdir() if p.is_file())
 
-        result = {
-            "input_dir": str(input_path),
-            "files": files,
-            "plugins": self.config.to_mapping(),
-            "dry_run": dry_run,
+        dataset = _load_metadata(metadata_path)
+        logger.info("Procesando %d registros", len(dataset))
+
+        details: list[dict[str, Any]] = []
+        processed = 0
+        total_tokens = 0
+        total_errors = 0
+        per_class_acc: dict[str, PhonemeStats] = {}
+
+        for sample in dataset:
+            detail: dict[str, Any] = {
+                "index": sample.index,
+                "audio_path": sample.audio_original,
+                "text": sample.text,
+                "lang": sample.lang,
+            }
+
+            try:
+                ref_ipa = self.textref.text_to_ipa(sample.text, sample.lang)
+                hyp_ipa = self.asr.transcribe_ipa(str(sample.audio_path))
+                compare_result = self.comparator.compare(ref_ipa, hyp_ipa)
+            except Exception as exc:  # pragma: no cover - defensive branch
+                logger.exception(
+                    "Error procesando registro %s (%s)",
+                    sample.index,
+                    sample.audio_original,
+                )
+                detail["error"] = str(exc)
+                details.append(detail)
+                continue
+
+            processed += 1
+            total_tokens += compare_result.total_ref_tokens
+            total_errors += (
+                compare_result.substitutions
+                + compare_result.insertions
+                + compare_result.deletions
+            )
+            _merge_per_class(per_class_acc, compare_result)
+
+            detail.update(
+                {
+                    "ref_ipa": ref_ipa,
+                    "hyp_ipa": hyp_ipa,
+                    "per": compare_result.per,
+                    "matches": compare_result.matches,
+                    "substitutions": compare_result.substitutions,
+                    "insertions": compare_result.insertions,
+                    "deletions": compare_result.deletions,
+                    "total_ref_tokens": compare_result.total_ref_tokens,
+                    "ops": _serialise_ops(compare_result.ops),
+                }
+            )
+            details.append(detail)
+
+        per_global = 0.0 if total_tokens == 0 else total_errors / total_tokens
+
+        return {
+            "config": self.config.to_mapping(),
+            "metadata": {
+                "path": str(Path(metadata_path).resolve()),
+                "total_items": len(dataset),
+            },
+            "summary": {
+                "procesados": processed,
+                "con_error": len(dataset) - processed,
+                "total_ref_tokens": total_tokens,
+                "total_errores": total_errors,
+            },
+            "per_global": per_global,
+            "per_por_clase": _serialise_per_class(per_class_acc),
+            "detalles": details,
         }
-
-        if dry_run:
-            logger.info("Ejecución en modo dry-run; no se procesa audio")
-            return result
-
-        logger.info(
-            "Kernel stub ejecutado con %d archivo(s) utilizando plugins %s",
-            len(files),
-            result["plugins"],
-        )
-        return result
 
 
 def _coerce_scalar(value: str) -> Any:
@@ -217,4 +274,82 @@ def _load_yaml(raw: str) -> Mapping[str, Any] | None:
         current[key] = _coerce_scalar(remainder)
         last_keys[-1] = key
 
+    return result
+
+
+def _load_metadata(path: str | Path) -> list[_Sample]:
+    metadata_path = Path(path)
+    if not metadata_path.exists():
+        raise FileNotFoundError(f"No se encontró el archivo de metadata: {path}")
+
+    with metadata_path.open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        if reader.fieldnames is None:
+            raise ValueError("El archivo de metadata debe tener encabezados")
+
+        required = {"audio_path", "text"}
+        missing = required.difference(reader.fieldnames)
+        if missing:
+            raise ValueError(
+                "Faltan columnas obligatorias en metadata: " + ", ".join(sorted(missing))
+            )
+
+        rows: list[_Sample] = []
+        base_dir = metadata_path.parent
+        for idx, row in enumerate(reader, start=1):
+            audio_raw = (row.get("audio_path") or "").strip()
+            text = (row.get("text") or "").strip()
+            lang_raw = (row.get("lang") or "").strip() or None
+
+            if not audio_raw:
+                raise ValueError(f"Fila {idx}: 'audio_path' no puede estar vacío")
+            if not text:
+                raise ValueError(f"Fila {idx}: 'text' no puede estar vacío")
+
+            rows.append(
+                _Sample(
+                    index=idx,
+                    audio_original=audio_raw,
+                    audio_path=(base_dir / audio_raw).resolve(),
+                    text=text,
+                    lang=lang_raw,
+                )
+            )
+
+    return rows
+
+
+def _merge_per_class(
+    accumulator: dict[str, PhonemeStats], compare_result: CompareResult
+) -> None:
+    for key, stats in compare_result.per_class.items():
+        current = accumulator.setdefault(key, PhonemeStats())
+        current.matches += stats.matches
+        current.substitutions += stats.substitutions
+        current.insertions += stats.insertions
+        current.deletions += stats.deletions
+
+
+def _serialise_ops(ops: Iterable[tuple[str, str, str]]) -> list[dict[str, str]]:
+    return [
+        {
+            "op": op,
+            "ref": ref,
+            "hyp": hyp,
+        }
+        for op, ref, hyp in ops
+    ]
+
+
+def _serialise_per_class(per_class: Mapping[str, PhonemeStats]) -> dict[str, dict[str, int]]:
+    result: dict[str, dict[str, int]] = {}
+    for key in sorted(per_class):
+        stats = per_class[key]
+        result[key] = {
+            "matches": stats.matches,
+            "substitutions": stats.substitutions,
+            "insertions": stats.insertions,
+            "deletions": stats.deletions,
+            "errors": stats.errors,
+        }
     return result

--- a/ipa_core/tests/test_cli_run.py
+++ b/ipa_core/tests/test_cli_run.py
@@ -1,0 +1,78 @@
+"""Integration tests for the CLI `ipa run` command."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from ipa_core.api.cli import app
+from ipa_core.backends.null_backend import NullASRBackend
+from ipa_core.compare.levenshtein import LevenshteinComparator
+from ipa_core.plugins import PLUGIN_GROUPS
+from ipa_core.textref.nop import NoopTextRef
+
+
+def test_cli_run_generates_reports(monkeypatch, tmp_path: Path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+plugins:
+  asr_backend: null
+  textref: noop
+  comparator: levenshtein
+"""
+    )
+
+    metadata_path = tmp_path / "metadata.csv"
+    metadata_path.write_text(
+        "audio_path,text,lang\nfile.wav,Texto de prueba,es\n",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "reports"
+
+    def fake_loader(group: str, name: str):
+        mapping = {
+            PLUGIN_GROUPS["asr"].entrypoint_group: {"null": NullASRBackend},
+            PLUGIN_GROUPS["textref"].entrypoint_group: {"noop": NoopTextRef},
+            PLUGIN_GROUPS["comparator"].entrypoint_group: {
+                "levenshtein": LevenshteinComparator
+            },
+        }
+        try:
+            return mapping[group][name]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Plugin no disponible en pruebas: {group}::{name}") from exc
+
+    monkeypatch.setattr("ipa_core.kernel.load_plugin", fake_loader)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--config",
+            str(config_path),
+            "--input",
+            str(metadata_path),
+            "--output",
+            str(output_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+    json_path = output_dir / "report.json"
+    csv_path = output_dir / "report.csv"
+    assert json_path.exists()
+    assert csv_path.exists()
+
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["summary"]["procesados"] == 1
+    assert "per_global" in payload
+    assert payload["detalles"]
+
+    csv_text = csv_path.read_text(encoding="utf-8")
+    assert "audio_path" in csv_text
+    assert "Reporte CSV generado en" in result.output

--- a/outputs/report.csv
+++ b/outputs/report.csv
@@ -1,0 +1,4 @@
+index,audio_path,text,lang,ref_ipa,hyp_ipa,per,matches,substitutions,insertions,deletions,total_ref_tokens,error
+1,sample_01.wav,Tono de referencia en 440 Hz,es,sɪstema,dɛmo,1.0,0,1,0,0,1,
+2,sample_02.wav,Tono de prueba en 554 Hz aproximados,es,sɪstema,dɛmo,1.0,0,1,0,0,1,
+3,sample_03.wav,Tono de cierre en 659 Hz aproximados,es,sɪstema,dɛmo,1.0,0,1,0,0,1,

--- a/outputs/report.json
+++ b/outputs/report.json
@@ -1,0 +1,93 @@
+{
+  "config": {
+    "asr_backend": "null",
+    "textref": "noop",
+    "comparator": "levenshtein",
+    "preprocessor": null
+  },
+  "metadata": {
+    "path": "/workspace/PronunciaPA/data/sample/metadata.csv",
+    "total_items": 3
+  },
+  "summary": {
+    "procesados": 3,
+    "con_error": 0,
+    "total_ref_tokens": 3,
+    "total_errores": 3
+  },
+  "per_global": 1.0,
+  "per_por_clase": {
+    "sɪstema": {
+      "matches": 0,
+      "substitutions": 3,
+      "insertions": 0,
+      "deletions": 0,
+      "errors": 3
+    }
+  },
+  "detalles": [
+    {
+      "index": 1,
+      "audio_path": "sample_01.wav",
+      "text": "Tono de referencia en 440 Hz",
+      "lang": "es",
+      "ref_ipa": "sɪstema",
+      "hyp_ipa": "dɛmo",
+      "per": 1.0,
+      "matches": 0,
+      "substitutions": 1,
+      "insertions": 0,
+      "deletions": 0,
+      "total_ref_tokens": 1,
+      "ops": [
+        {
+          "op": "substitution",
+          "ref": "sɪstema",
+          "hyp": "dɛmo"
+        }
+      ]
+    },
+    {
+      "index": 2,
+      "audio_path": "sample_02.wav",
+      "text": "Tono de prueba en 554 Hz aproximados",
+      "lang": "es",
+      "ref_ipa": "sɪstema",
+      "hyp_ipa": "dɛmo",
+      "per": 1.0,
+      "matches": 0,
+      "substitutions": 1,
+      "insertions": 0,
+      "deletions": 0,
+      "total_ref_tokens": 1,
+      "ops": [
+        {
+          "op": "substitution",
+          "ref": "sɪstema",
+          "hyp": "dɛmo"
+        }
+      ]
+    },
+    {
+      "index": 3,
+      "audio_path": "sample_03.wav",
+      "text": "Tono de cierre en 659 Hz aproximados",
+      "lang": "es",
+      "ref_ipa": "sɪstema",
+      "hyp_ipa": "dɛmo",
+      "per": 1.0,
+      "matches": 0,
+      "substitutions": 1,
+      "insertions": 0,
+      "deletions": 0,
+      "total_ref_tokens": 1,
+      "ops": [
+        {
+          "op": "substitution",
+          "ref": "sɪstema",
+          "hyp": "dɛmo"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add kernel execution pipeline that loads metadata, invokes plugins, and aggregates PER metrics
- extend CLI run command to generate JSON/CSV reports using the configured plugins
- add local config, sample outputs, and integration tests for the new CLI behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddd33e6a64832a8f34d9f9d3dd8798