### PR TITLE
Add FastAPI API and frontend integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,41 @@ Luego instala las dependencias Python (incluido `phonemizer`):
 pip install -e .
 ```
 
+Para automatizar la preparación del entorno (dependencias de Python y descarga del
+modelo Whisper-IPA) puedes ejecutar:
+
+```bash
+./scripts/install_models.sh
+```
+
+Este script verificará si `espeak-ng` está instalado y descargará el modelo
+`neurlang/ipa-whisper-base` al caché local de Hugging Face.
+
 > Nota: si `phonemizer` no está disponible el plugin incluye un fallback muy
 > básico para pruebas que solo cubre algunos ejemplos en español e inglés.
+
+## API HTTP y frontend
+
+El módulo `ipa_core.api.server` expone una API HTTP basada en FastAPI que se
+integra con el frontend estático incluido en `frontend/public/`. Para probar el
+flujo completo:
+
+1. Inicia el backend:
+
+   ```bash
+   uvicorn ipa_core.api.server:app --host 0.0.0.0 --port 8000
+   ```
+
+2. Sirve el frontend (por ejemplo usando el script disponible en `package.json`):
+
+   ```bash
+   cd frontend
+   npm run start
+   ```
+
+3. Abre `http://localhost:3000` en tu navegador y utiliza la sección "Conecta
+   con el núcleo IPA" para subir un audio y visualizar las métricas generadas
+   por el backend.
 
 ## Datos de ejemplo
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -85,6 +85,88 @@
     </div>
   </section>
 
+  <section id="demo" class="py-20 bg-white">
+    <div class="max-w-6xl mx-auto px-6">
+      <div class="text-center mb-16">
+        <h2 class="text-4xl md:text-5xl font-bold text-gray-800 mb-4">Conecta con el núcleo IPA</h2>
+        <p class="text-xl text-gray-600">Sube un audio y obtén métricas en tiempo real usando la API de PronunciaPA</p>
+      </div>
+      <div class="grid gap-12 lg:grid-cols-2 items-start">
+        <div class="bg-gradient-to-br from-purple-50 to-blue-50 p-8 rounded-2xl shadow-lg border border-purple-100">
+          <h3 class="text-2xl font-semibold text-gray-800 mb-4">Plugins detectados</h3>
+          <p class="text-gray-600 mb-6">La API consulta los plugins instalados en el backend para mostrar qué componentes están disponibles.</p>
+          <div id="pluginLoading" class="text-sm text-purple-600 font-medium">Cargando plugins registrados...</div>
+          <ul id="pluginList" class="space-y-3"></ul>
+          <div id="pluginError" class="hidden text-sm text-red-600 mt-4"></div>
+        </div>
+        <div class="bg-white border border-gray-200 rounded-2xl shadow-xl p-8">
+          <h3 class="text-2xl font-semibold text-gray-800 mb-4">Ejecutar un análisis</h3>
+          <p class="text-gray-600 mb-6">Selecciona un archivo de audio (formato WAV/MP3) y proporciona el texto de referencia. El backend generará la transcripción IPA y calculará la métrica PER.</p>
+          <form id="analysisForm" class="space-y-6" enctype="multipart/form-data">
+            <div>
+              <label for="audioInput" class="block text-sm font-medium text-gray-700 mb-2">Archivo de audio</label>
+              <input id="audioInput" name="audio" type="file" accept="audio/wav,audio/x-wav,audio/mpeg,audio/mp3,audio/*" required class="w-full border border-gray-300 rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-purple-400">
+              <p class="text-xs text-gray-500 mt-2">Para pruebas rápidas puedes utilizar los WAV generados en <code class="bg-gray-100 px-1 rounded">data/sample/</code>.</p>
+            </div>
+            <div>
+              <label for="textInput" class="block text-sm font-medium text-gray-700 mb-2">Texto de referencia</label>
+              <textarea id="textInput" name="text" rows="3" required class="w-full border border-gray-300 rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-purple-400" placeholder="Escribe el texto pronunciado en el audio"></textarea>
+            </div>
+            <div>
+              <label for="langInput" class="block text-sm font-medium text-gray-700 mb-2">Idioma (opcional)</label>
+              <input id="langInput" name="lang" type="text" class="w-full border border-gray-300 rounded-xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-purple-400" placeholder="es, en, etc.">
+            </div>
+            <button type="submit" class="w-full bg-gradient-to-r from-purple-600 to-blue-600 text-white px-6 py-3 rounded-xl font-semibold shadow-lg hover:shadow-xl transition-all transform hover:-translate-y-1">Analizar pronunciación</button>
+          </form>
+          <div id="analysisStatus" class="hidden mt-6 text-sm text-purple-600 font-medium">Procesando audio...</div>
+          <div id="analysisError" class="hidden mt-6 text-sm text-red-600"></div>
+          <div id="analysisResult" class="hidden mt-8 border border-gray-200 rounded-xl p-6 bg-gradient-to-br from-white to-purple-50">
+            <h4 class="text-xl font-semibold text-gray-800 mb-4">Resultados del análisis</h4>
+            <dl class="grid grid-cols-1 gap-4 text-sm text-gray-700 md:grid-cols-2">
+              <div>
+                <dt class="font-semibold text-gray-600">Texto</dt>
+                <dd id="resultText" class="mt-1 break-words"></dd>
+              </div>
+              <div>
+                <dt class="font-semibold text-gray-600">Idioma</dt>
+                <dd id="resultLang" class="mt-1"></dd>
+              </div>
+              <div>
+                <dt class="font-semibold text-gray-600">IPA referencia</dt>
+                <dd id="resultRefIpa" class="mt-1 font-mono text-purple-700"></dd>
+              </div>
+              <div>
+                <dt class="font-semibold text-gray-600">IPA hipótesis</dt>
+                <dd id="resultHypIpa" class="mt-1 font-mono text-blue-700"></dd>
+              </div>
+              <div>
+                <dt class="font-semibold text-gray-600">PER global</dt>
+                <dd id="resultPer" class="mt-1 text-lg font-bold text-purple-600"></dd>
+              </div>
+              <div>
+                <dt class="font-semibold text-gray-600">Resumen de operaciones</dt>
+                <dd class="mt-1 text-sm text-gray-600">
+                  <span id="resultMatches" class="mr-3"></span>
+                  <span id="resultSubstitutions" class="mr-3"></span>
+                  <span id="resultInsertions" class="mr-3"></span>
+                  <span id="resultDeletions"></span>
+                </dd>
+              </div>
+            </dl>
+            <div class="mt-6">
+              <h5 class="text-sm font-semibold text-gray-600 mb-2">Operaciones (máx. 10)</h5>
+              <ul id="resultOps" class="space-y-2 text-sm text-gray-700"></ul>
+            </div>
+            <div class="mt-6">
+              <h5 class="text-sm font-semibold text-gray-600 mb-2">Métricas por fonema</h5>
+              <ul id="resultPerClass" class="space-y-2 text-sm text-gray-700"></ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <section id="caracteristicas" class="py-20 bg-white">
     <div class="max-w-6xl mx-auto px-6">
       <div class="text-center mb-16">
@@ -221,6 +303,195 @@
       section.style.transition = 'opacity 0.6s ease, transform 0.6s ease';
       observer.observe(section);
     });
+
+    const API_BASE_URL = window.PRONUNCIAPA_API_BASE || 'http://localhost:8000';
+    const pluginList = document.getElementById('pluginList');
+    const pluginLoading = document.getElementById('pluginLoading');
+    const pluginError = document.getElementById('pluginError');
+    const analysisForm = document.getElementById('analysisForm');
+    const analysisStatus = document.getElementById('analysisStatus');
+    const analysisError = document.getElementById('analysisError');
+    const analysisResult = document.getElementById('analysisResult');
+    const resultText = document.getElementById('resultText');
+    const resultLang = document.getElementById('resultLang');
+    const resultRefIpa = document.getElementById('resultRefIpa');
+    const resultHypIpa = document.getElementById('resultHypIpa');
+    const resultPer = document.getElementById('resultPer');
+    const resultMatches = document.getElementById('resultMatches');
+    const resultSubstitutions = document.getElementById('resultSubstitutions');
+    const resultInsertions = document.getElementById('resultInsertions');
+    const resultDeletions = document.getElementById('resultDeletions');
+    const resultOps = document.getElementById('resultOps');
+    const resultPerClass = document.getElementById('resultPerClass');
+
+    async function loadPlugins() {
+      if (!pluginList) {
+        return;
+      }
+      try {
+        const response = await fetch(`${API_BASE_URL}/api/plugins`);
+        if (!response.ok) {
+          throw new Error('Respuesta inesperada del servidor');
+        }
+        const data = await response.json();
+        const entries = Object.entries(data.plugins || {});
+        pluginList.innerHTML = '';
+        if (!entries.length) {
+          pluginList.innerHTML = '<li class="text-sm text-gray-600">No se encontraron plugins registrados.</li>';
+        } else {
+          entries.forEach(([group, names]) => {
+            const item = document.createElement('li');
+            item.className = 'bg-white rounded-xl px-4 py-3 shadow flex flex-col sm:flex-row sm:items-center sm:justify-between';
+            const title = document.createElement('span');
+            title.className = 'font-semibold text-gray-700 capitalize';
+            title.textContent = group;
+            const values = document.createElement('span');
+            values.className = 'text-sm text-gray-500 mt-2 sm:mt-0';
+            values.textContent = (names && names.length) ? names.join(', ') : 'Sin plugins disponibles';
+            item.appendChild(title);
+            item.appendChild(values);
+            pluginList.appendChild(item);
+          });
+        }
+        if (pluginLoading) {
+          pluginLoading.classList.add('hidden');
+        }
+        if (pluginError) {
+          pluginError.classList.add('hidden');
+        }
+      } catch (error) {
+        if (pluginLoading) {
+          pluginLoading.classList.add('hidden');
+        }
+        if (pluginError) {
+          pluginError.textContent = 'No se pudieron obtener los plugins: ' + (error instanceof Error ? error.message : 'Error desconocido');
+          pluginError.classList.remove('hidden');
+        }
+      }
+    }
+
+    function renderList(container, items, formatItem) {
+      container.innerHTML = '';
+      if (!Array.isArray(items) || !items.length) {
+        const empty = document.createElement('li');
+        empty.className = 'text-sm text-gray-500';
+        empty.textContent = 'Sin datos disponibles.';
+        container.appendChild(empty);
+        return;
+      }
+      items.forEach((item, index) => {
+        if (index >= 10) {
+          return;
+        }
+        const li = document.createElement('li');
+        li.className = 'bg-white/60 border border-gray-200 rounded-lg px-3 py-2';
+        li.textContent = formatItem(item);
+        container.appendChild(li);
+      });
+    }
+
+    function renderPerClassList(container, perClass) {
+      container.innerHTML = '';
+      const entries = Object.entries(perClass || {});
+      if (!entries.length) {
+        const empty = document.createElement('li');
+        empty.className = 'text-sm text-gray-500';
+        empty.textContent = 'Sin estadísticas registradas.';
+        container.appendChild(empty);
+        return;
+      }
+      entries.slice(0, 10).forEach(([phoneme, stats]) => {
+        const li = document.createElement('li');
+        li.className = 'bg-white/60 border border-gray-200 rounded-lg px-3 py-2 flex flex-wrap gap-3';
+        const title = document.createElement('span');
+        title.className = 'font-semibold text-gray-700';
+        title.textContent = phoneme;
+        const details = document.createElement('span');
+        details.className = 'text-sm text-gray-500';
+        details.textContent = `Aciertos ${stats.matches} · Sustituciones ${stats.substitutions} · Inserciones ${stats.insertions} · Eliminaciones ${stats.deletions}`;
+        li.appendChild(title);
+        li.appendChild(details);
+        container.appendChild(li);
+      });
+    }
+
+    function showAnalysisResult(payload) {
+      if (!analysisResult) {
+        return;
+      }
+      resultText.textContent = payload.text || '—';
+      resultLang.textContent = payload.lang || '—';
+      resultRefIpa.textContent = payload.ref_ipa || '—';
+      resultHypIpa.textContent = payload.hyp_ipa || '—';
+      if (typeof payload.per === 'number') {
+        resultPer.textContent = `${(payload.per * 100).toFixed(2)} %`;
+      } else {
+        resultPer.textContent = '—';
+      }
+      resultMatches.textContent = `✔︎ ${payload.matches ?? 0} aciertos`;
+      resultSubstitutions.textContent = `↺ ${payload.substitutions ?? 0} sustituciones`;
+      resultInsertions.textContent = `＋ ${payload.insertions ?? 0} inserciones`;
+      resultDeletions.textContent = `− ${payload.deletions ?? 0} eliminaciones`;
+
+      renderList(resultOps, payload.ops, (item) => {
+        const ref = item.ref || '∅';
+        const hyp = item.hyp || '∅';
+        return `${item.op}: ${ref} → ${hyp}`;
+      });
+      renderPerClassList(resultPerClass, payload.per_class);
+
+      analysisResult.classList.remove('hidden');
+    }
+
+    if (analysisForm) {
+      analysisForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (analysisError) {
+          analysisError.classList.add('hidden');
+        }
+        if (analysisStatus) {
+          analysisStatus.textContent = 'Procesando audio...';
+          analysisStatus.classList.remove('hidden');
+        }
+        if (analysisResult) {
+          analysisResult.classList.add('hidden');
+        }
+
+        const formData = new FormData(analysisForm);
+
+        try {
+          const response = await fetch(`${API_BASE_URL}/api/analyze`, {
+            method: 'POST',
+            body: formData,
+          });
+          if (!response.ok) {
+            let message = 'No se pudo procesar el análisis.';
+            try {
+              const errorPayload = await response.json();
+              if (errorPayload && errorPayload.detail) {
+                message = errorPayload.detail;
+              }
+            } catch (parseError) {
+              message = 'No se pudo interpretar la respuesta del servidor.';
+            }
+            throw new Error(message);
+          }
+          const payload = await response.json();
+          showAnalysisResult(payload);
+        } catch (err) {
+          if (analysisError) {
+            analysisError.textContent = err instanceof Error ? err.message : 'Ocurrió un error inesperado.';
+            analysisError.classList.remove('hidden');
+          }
+        } finally {
+          if (analysisStatus) {
+            analysisStatus.classList.add('hidden');
+          }
+        }
+      });
+    }
+
+    loadPlugins();
   </script>
 </body>
 </html>

--- a/ipa_core/api/server.py
+++ b/ipa_core/api/server.py
@@ -1,0 +1,182 @@
+"""HTTP API para exponer el microkernel a aplicaciones externas."""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+
+from ipa_core.compare.base import PhonemeStats
+from ipa_core.kernel import Kernel, KernelConfig
+from ipa_core.plugins import PLUGIN_GROUPS, list_plugins
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONFIG_PATH = Path(os.getenv("IPA_KERNEL_CONFIG", "config/ipa_kernel.yaml"))
+
+
+class AnalysisService:
+    """Pequeño contenedor que orquesta el kernel y serializa respuestas."""
+
+    def __init__(
+        self,
+        *,
+        kernel: Kernel | None = None,
+        config: KernelConfig | None = None,
+        config_path: str | Path | None = None,
+    ) -> None:
+        if kernel is not None:
+            self._kernel = kernel
+            self.config = kernel.config
+            return
+
+        if config is not None:
+            self.config = config
+        else:
+            self.config = self._load_config(config_path)
+
+        self._kernel = Kernel(self.config)
+
+    @staticmethod
+    def _load_config(config_path: str | Path | None) -> KernelConfig:
+        path = Path(config_path) if config_path is not None else DEFAULT_CONFIG_PATH
+        try:
+            return KernelConfig.from_yaml(path)
+        except FileNotFoundError:
+            logger.warning("No se encontró %s, usando configuración por defecto", path)
+        except Exception as exc:  # pragma: no cover - logging defensivo
+            logger.warning("No se pudo cargar la configuración %s: %s", path, exc)
+        return KernelConfig()
+
+    @property
+    def kernel(self) -> Kernel:
+        return self._kernel
+
+    def analyze(self, *, text: str, audio_path: Path, lang: str | None = None) -> Dict[str, Any]:
+        if not text or not text.strip():
+            raise ValueError("El texto de referencia no puede estar vacío")
+
+        if self._kernel.asr is None or self._kernel.textref is None or self._kernel.comparator is None:
+            raise RuntimeError("El kernel no cuenta con todos los plugins configurados")
+
+        ref_ipa = self._kernel.textref.text_to_ipa(text, lang)
+        hyp_ipa = self._kernel.asr.transcribe_ipa(str(audio_path))
+        compare_result = self._kernel.comparator.compare(ref_ipa, hyp_ipa)
+
+        return {
+            "text": text,
+            "lang": lang,
+            "ref_ipa": ref_ipa,
+            "hyp_ipa": hyp_ipa,
+            "per": compare_result.per,
+            "matches": compare_result.matches,
+            "substitutions": compare_result.substitutions,
+            "insertions": compare_result.insertions,
+            "deletions": compare_result.deletions,
+            "total_ref_tokens": compare_result.total_ref_tokens,
+            "ops": self._serialise_ops(compare_result.ops),
+            "per_class": self._serialise_per_class(compare_result.per_class.items()),
+            "config": self._kernel.config.to_mapping(),
+        }
+
+    @staticmethod
+    def _serialise_ops(ops: Iterable[tuple[str, str, str]]) -> list[dict[str, str]]:
+        return [
+            {
+                "op": op,
+                "ref": ref,
+                "hyp": hyp,
+            }
+            for op, ref, hyp in ops
+        ]
+
+    @staticmethod
+    def _serialise_per_class(
+        items: Iterable[tuple[str, PhonemeStats]]
+    ) -> dict[str, dict[str, int]]:
+        serialised: dict[str, dict[str, int]] = {}
+        for key, stats in items:
+            serialised[key] = {
+                "matches": stats.matches,
+                "substitutions": stats.substitutions,
+                "insertions": stats.insertions,
+                "deletions": stats.deletions,
+                "errors": stats.errors,
+            }
+        return serialised
+
+
+def create_app(
+    *,
+    service: AnalysisService | None = None,
+    config: KernelConfig | None = None,
+    config_path: str | Path | None = None,
+) -> FastAPI:
+    """Crea una instancia de FastAPI ya configurada con CORS y rutas."""
+
+    app = FastAPI(title="PronunciaPA API", version="0.1.0")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"]
+    )
+
+    app.state.analysis_service = service or AnalysisService(config=config, config_path=config_path)
+
+    @app.get("/health", tags=["status"])
+    async def healthcheck() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/api/plugins", tags=["metadata"])
+    async def get_plugins() -> dict[str, dict[str, list[str]]]:
+        plugins: dict[str, list[str]] = {}
+        for group_key, group in PLUGIN_GROUPS.items():
+            plugins[group_key] = list_plugins(group.entrypoint_group)
+        return {"plugins": plugins}
+
+    @app.post("/api/analyze", tags=["analysis"])
+    async def analyze(  # noqa: PLR0913 - FastAPI necesita la firma extendida
+        request: Request,
+        text: str = Form(...),
+        lang: str | None = Form(None),
+        audio: UploadFile = File(...),
+    ) -> dict[str, Any]:
+        suffix = Path(audio.filename or "audio.wav").suffix or ".wav"
+
+        try:
+            contents = await audio.read()
+        finally:
+            await audio.close()
+
+        if not contents:
+            raise HTTPException(status_code=400, detail="El archivo de audio está vacío")
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            tmp.write(contents)
+            tmp_path = Path(tmp.name)
+
+        service: AnalysisService = request.app.state.analysis_service
+
+        try:
+            return service.analyze(text=text, lang=lang, audio_path=tmp_path)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except Exception as exc:  # pragma: no cover - fallback defensivo
+            logger.exception("Error analizando el audio")
+            raise HTTPException(status_code=500, detail="Error interno al procesar el análisis") from exc
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    return app
+
+
+app = create_app()
+
+__all__ = ["AnalysisService", "app", "create_app"]

--- a/ipa_core/api/tests/test_server.py
+++ b/ipa_core/api/tests/test_server.py
@@ -1,0 +1,118 @@
+"""Tests for the FastAPI server wiring."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from ipa_core.api.server import AnalysisService, create_app
+from ipa_core.compare.base import CompareResult, PhonemeStats
+from ipa_core.kernel import KernelConfig
+
+
+class DummyASR:
+    def __init__(self) -> None:
+        self.last_path: str | None = None
+
+    def transcribe_ipa(self, audio_path: str) -> str:
+        self.last_path = audio_path
+        return "dɛmo"
+
+
+class DummyTextRef:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str | None]] = []
+
+    def text_to_ipa(self, text: str, lang: str | None = None) -> str:
+        self.calls.append((text, lang))
+        return "sɪstema"
+
+
+class DummyComparator:
+    def compare(self, ref_ipa: str, hyp_ipa: str) -> CompareResult:
+        stats = PhonemeStats(matches=1, substitutions=1)
+        return CompareResult(
+            per=0.25,
+            ops=[("match", "s", "d"), ("substitution", "ɪ", "ɛ")],
+            total_ref_tokens=4,
+            matches=1,
+            substitutions=1,
+            insertions=0,
+            deletions=0,
+            per_class={"s": stats},
+        )
+
+
+class DummyKernel:
+    def __init__(self) -> None:
+        self.config = KernelConfig(asr_backend="null", textref="noop", comparator="noop")
+        self.asr = DummyASR()
+        self.textref = DummyTextRef()
+        self.comparator = DummyComparator()
+
+
+def create_test_client() -> tuple[TestClient, DummyKernel]:
+    kernel = DummyKernel()
+    service = AnalysisService(kernel=kernel)
+    app = create_app(service=service)
+    return TestClient(app), kernel
+
+
+def test_healthcheck_returns_ok() -> None:
+    client, _ = create_test_client()
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_plugins_endpoint_uses_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    client, _ = create_test_client()
+
+    def fake_list_plugins(group: str) -> list[str]:  # pragma: no cover - trivial wrapper
+        return [group]
+
+    monkeypatch.setattr("ipa_core.api.server.list_plugins", fake_list_plugins)
+
+    response = client.get("/api/plugins")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload["plugins"]) == {"asr", "textref", "comparator", "preprocessor"}
+    assert payload["plugins"]["asr"] == ["ipa_core.backends.asr"]
+
+
+def test_analyze_serialises_response() -> None:
+    client, kernel = create_test_client()
+    files = {"audio": ("sample.wav", b"data", "audio/wav")}
+    data = {"text": "Hola", "lang": "es"}
+
+    response = client.post("/api/analyze", data=data, files=files)
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["ref_ipa"] == "sɪstema"
+    assert payload["hyp_ipa"] == "dɛmo"
+    assert pytest.approx(payload["per"], rel=1e-6) == 0.25
+    assert payload["config"]["asr_backend"] == "null"
+    assert payload["ops"][0] == {"op": "match", "ref": "s", "hyp": "d"}
+    assert payload["per_class"]["s"]["errors"] == 1
+    assert kernel.asr.last_path is not None
+    assert kernel.asr.last_path.endswith(".wav")
+
+
+def test_analyze_rejects_empty_audio() -> None:
+    client, _ = create_test_client()
+
+    response = client.post(
+        "/api/analyze",
+        data={"text": "Hola"},
+        files={"audio": ("empty.wav", b"", "audio/wav")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "El archivo de audio está vacío"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "transformers>=4.37",
     "torch>=2.1",
     "phonemizer>=3.2",
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.24",
+    "python-multipart>=0.0.7",
 ]
 
 [project.scripts]

--- a/scripts/install_models.sh
+++ b/scripts/install_models.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Bootstrap de modelos y dependencias para el backend de PronunciaPA.
+# Ejecuta este script desde la raíz del repositorio para preparar un entorno local.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "[PronunciaPA] Instalando dependencias de Python (incluye FastAPI y plugins)..."
+python -m pip install --upgrade pip
+python -m pip install -e "${ROOT_DIR}"
+
+if ! command -v espeak-ng >/dev/null 2>&1; then
+  echo "[Aviso] 'espeak-ng' no está instalado. En sistemas Debian/Ubuntu ejecute:" >&2
+  echo "        sudo apt-get update && sudo apt-get install -y espeak-ng" >&2
+fi
+
+echo "[PronunciaPA] Descargando el modelo Whisper IPA desde Hugging Face (necesita conexión a Internet)..."
+python - <<'PY'
+from transformers import pipeline
+
+print("[Descarga] Creando pipeline 'automatic-speech-recognition' con el modelo neurlang/ipa-whisper-base...")
+pipeline("automatic-speech-recognition", model="neurlang/ipa-whisper-base", chunk_length_s=1.0)
+print("[Descarga] Modelo listo en el cache local de Hugging Face.")
+PY
+
+echo "[PronunciaPA] Instalación completada."


### PR DESCRIPTION
## Summary
- add a FastAPI service that exposes health, plugin listing, and analysis endpoints for the IPA kernel
- enhance the static frontend with a demo section that calls the new API to list plugins and upload audio for analysis
- document the workflow, declare new dependencies, and provide a helper script to install models and requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddd7c7cdec832ab2d8c7758cf2943a