### PR TITLE
Refactor domain entities and navigation to bottom bar

### DIFF
--- a/pronunciapa_client/lib/main.dart
+++ b/pronunciapa_client/lib/main.dart
@@ -3,6 +3,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'presentation/pages/home_page.dart';
+import 'presentation/pages/ipa_learn_page.dart';
+import 'presentation/pages/ipa_practice_page.dart';
+import 'presentation/pages/progress_roadmap_page.dart';
+import 'presentation/pages/settings_page.dart';
+import 'presentation/providers/preferences_provider.dart';
 import 'presentation/theme/app_theme.dart';
 import 'core/debug/debug.dart';
 
@@ -48,15 +53,13 @@ void main() {
   );
 }
 
-/// Provider para el modo del tema
-final themeModeProvider = StateProvider<ThemeMode>((ref) => ThemeMode.dark);
-
 class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final themeMode = ref.watch(themeModeProvider);
+    final prefs = ref.watch(preferencesProvider);
+    final themeMode = prefs.darkMode ? ThemeMode.dark : ThemeMode.light;
 
     return MaterialApp(
       title: 'PronunciaPA',
@@ -64,8 +67,69 @@ class MyApp extends ConsumerWidget {
       theme: AppTheme.light,
       darkTheme: AppTheme.dark,
       themeMode: themeMode,
-      // DebugOverlay injects the floating debug FAB in debug builds only.
-      home: const DebugOverlay(child: HomePage()),
+      home: const DebugOverlay(child: MainShell()),
+    );
+  }
+}
+
+/// Main application shell with Material 3 NavigationBar.
+/// Each tab is kept alive via IndexedStack so state is preserved.
+class MainShell extends StatefulWidget {
+  const MainShell({super.key});
+
+  @override
+  State<MainShell> createState() => _MainShellState();
+}
+
+class _MainShellState extends State<MainShell> {
+  int _selectedIndex = 0;
+
+  static const _pages = <Widget>[
+    HomePage(),
+    IpaLearnPage(),
+    IpaPracticePage(),
+    ProgressRoadmapPage(),
+    SettingsPage(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(
+        index: _selectedIndex,
+        children: _pages,
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _selectedIndex,
+        onDestinationSelected: (index) => setState(() => _selectedIndex = index),
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.mic_none),
+            selectedIcon: Icon(Icons.mic),
+            label: 'Practica',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.school_outlined),
+            selectedIcon: Icon(Icons.school),
+            label: 'Aprende',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.psychology_outlined),
+            selectedIcon: Icon(Icons.psychology),
+            label: 'Ejercicios',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.show_chart),
+            selectedIcon: Icon(Icons.show_chart),
+            label: 'Progreso',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.settings_outlined),
+            selectedIcon: Icon(Icons.settings),
+            label: 'Config',
+          ),
+        ],
+      ),
     );
   }
 }

--- a/pronunciapa_client/lib/presentation/pages/home_page.dart
+++ b/pronunciapa_client/lib/presentation/pages/home_page.dart
@@ -2,17 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
 import '../widgets/recorder_widget.dart';
-import '../widgets/ipa_display_widget.dart';
-import '../widgets/diff_viewer_widget.dart';
 import '../providers/api_provider.dart';
 import '../providers/preferences_provider.dart';
 import '../../domain/entities/ipa_cli.dart';
-import 'settings_page.dart';
 import 'results_page.dart';
-import 'ipa_practice_page.dart';
-import 'ipa_learn_page.dart';
 import 'models_page.dart';
-import 'progress_roadmap_page.dart';
 import '../theme/app_theme.dart';
 import '../widgets/app_background.dart';
 
@@ -44,49 +38,14 @@ class _HomePageState extends ConsumerState<HomePage> {
         title: const Text('PronunciaPA'),
         actions: [
           IconButton(
-            icon: const Icon(Icons.school),
-            onPressed: () {
-               Navigator.of(context).push(
-                 MaterialPageRoute(builder: (_) => const IpaLearnPage()),
-               );
-            },
-            tooltip: 'Learn IPA',
-          ),
-          IconButton(
-            icon: const Icon(Icons.psychology),
-            onPressed: () {
-               Navigator.of(context).push(
-                 MaterialPageRoute(builder: (_) => const IpaPracticePage()),
-               );
-            },
-            tooltip: 'Práctica IPA',
-          ),
-          IconButton(
-            icon: const Icon(Icons.show_chart),
-            onPressed: () {
-               Navigator.of(context).push(
-                 MaterialPageRoute(builder: (_) => const ProgressRoadmapPage()),
-               );
-            },
-            tooltip: 'Mi progreso',
-          ),
-          IconButton(
             icon: const Icon(Icons.extension),
             onPressed: () {
-               Navigator.of(context).push(
-                 MaterialPageRoute(builder: (_) => const ModelsPage()),
-               );
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const ModelsPage()),
+              );
             },
             tooltip: 'Gestión de Modelos',
           ),
-          IconButton(
-            icon: const Icon(Icons.settings),
-            onPressed: () {
-               Navigator.of(context).push(
-                 MaterialPageRoute(builder: (_) => const SettingsPage()),
-               );
-            },
-          )
         ],
       ),
       body: Stack(
@@ -204,6 +163,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                   lang: prefs.lang,
                   evaluationLevel: prefs.mode.name,
                   mode: prefs.comparisonMode,
+                  feedbackLevel: prefs.feedbackLevel,
                 );
                 final updatedState = ref.read(apiNotifierProvider);
                 if (updatedState.result != null && mounted) {
@@ -238,7 +198,7 @@ class _HomePageState extends ConsumerState<HomePage> {
       for (var op in result.ops!) {
         PhonemeOperation operation;
         String phoneme;
-        
+
         switch (op.op) {
           case 'eq':
             operation = PhonemeOperation.correct;
@@ -246,7 +206,7 @@ class _HomePageState extends ConsumerState<HomePage> {
             break;
           case 'sub':
             operation = PhonemeOperation.substitute;
-            phoneme = op.hyp ?? ''; // Mostramos lo que dijo el usuario
+            phoneme = op.hyp ?? '';
             break;
           case 'del':
             operation = PhonemeOperation.delete;
@@ -260,19 +220,22 @@ class _HomePageState extends ConsumerState<HomePage> {
             operation = PhonemeOperation.correct;
             phoneme = op.hyp ?? op.ref ?? '';
         }
-        
+
         phonemes.add(PhonemeResult(phoneme: phoneme, operation: operation));
       }
     }
 
+    // Use rich feedback from /v1/feedback if available, otherwise null
+    final feedbackPayload = ref.read(apiNotifierProvider).feedbackResult?.feedback;
+
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (context) => ResultsPage(
-          score: result.score ?? 0.0, // Backend now returns 0-100
-          targetIpa: result.targetIpa ?? result.meta?['target_ipa'] ?? '',
+          score: result.score ?? 0.0,
+          targetIpa: result.targetIpa ?? result.meta?['target_ipa'] as String? ?? '',
           observedIpa: result.ipa,
           phonemes: phonemes,
-          feedback: result.meta?['feedback']?['summary'],
+          feedbackPayload: feedbackPayload,
         ),
       ),
     );
@@ -356,96 +319,6 @@ class _HomePageState extends ConsumerState<HomePage> {
           ),
         ],
       ),
-    );
-  }
-
-  Widget _buildResultCard(ThemeData theme, TranscriptionResult result) {
-    final score = result.score ?? 0.0; // Backend now returns 0-100
-    final isGood = score > 80;
-
-    return GlassCard(
-      padding: const EdgeInsets.all(20),
-      child: Column(
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text("Resultado", style: theme.textTheme.titleMedium),
-                  if (result.score != null)
-                    Text(
-                      "${score.toStringAsFixed(0)}% Match",
-                      style: theme.textTheme.headlineMedium?.copyWith(
-                        color: isGood ? AppTheme.success : AppTheme.warning,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                ],
-              ),
-              Icon(
-                isGood ? Icons.check_circle : Icons.warning_amber,
-                size: 48,
-                color: isGood ? AppTheme.success : AppTheme.warning,
-              ),
-            ],
-          ),
-          const SizedBox(height: 24),
-          Text("Phonetic Breakdown", style: theme.textTheme.labelLarge),
-          const SizedBox(height: 12),
-
-          if (result.ops != null && result.ops!.isNotEmpty)
-            DiffViewerWidget(
-              tokens: result.ops!.map((op) {
-                DiffTag tag;
-                switch (op.op) {
-                  case 'eq':
-                    tag = DiffTag.match;
-                    break;
-                  case 'sub':
-                    tag = DiffTag.substitution;
-                    break;
-                  case 'del':
-                    tag = DiffTag.deletion;
-                    break;
-                  case 'ins':
-                    tag = DiffTag.insertion;
-                    break;
-                  default:
-                    tag = DiffTag.match;
-                }
-                return DiffToken(op.hyp ?? op.ref ?? '', tag);
-              }).toList(),
-            )
-          else if (result.alignment != null)
-            _buildLegacyAlignment(result.alignment!)
-          else
-            IpaDisplayWidget(label: "Raw IPA", ipa: result.ipa),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildLegacyAlignment(List<List<String?>> alignment) {
-    // Fallback for old-style alignment display
-    return Wrap(
-      spacing: 8,
-      runSpacing: 12,
-      alignment: WrapAlignment.center,
-      children: alignment.map((pair) {
-        final ref = pair[0];
-        final hyp = pair[1];
-        final match = ref == hyp;
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-          decoration: BoxDecoration(
-            color: match ? Colors.green.withOpacity(0.15) : Colors.red.withOpacity(0.15),
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: Text(hyp ?? ref ?? '', style: const TextStyle(fontFamily: 'monospace')),
-        );
-      }).toList(),
     );
   }
 

--- a/pronunciapa_client/lib/presentation/pages/ipa_learn_page.dart
+++ b/pronunciapa_client/lib/presentation/pages/ipa_learn_page.dart
@@ -40,9 +40,9 @@ class _IpaLearnPageState extends ConsumerState<IpaLearnPage> {
                 const Icon(Icons.arrow_drop_down),
               ],
             ),
-            onSelected: (lang) {
+            onSelected: (lang) async {
               setState(() => _selectedLang = lang);
-              ref.read(ipaLearningProvider.notifier).loadContent(lang);
+              await ref.read(ipaLearningProvider.notifier).loadContent(lang);
             },
             itemBuilder: (context) => [
               const PopupMenuItem(value: 'en', child: Text('🇺🇸 English')),

--- a/pronunciapa_client/lib/presentation/pages/ipa_practice_page.dart
+++ b/pronunciapa_client/lib/presentation/pages/ipa_practice_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/ipa_practice_provider.dart';
 import '../providers/preferences_provider.dart';
+import '../providers/repository_provider.dart';
 import '../theme/app_theme.dart';
 import '../widgets/app_background.dart';
 import '../widgets/audio_player_button.dart';
@@ -24,6 +25,8 @@ class IpaPracticePage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final practiceState = ref.watch(ipaPracticeProvider);
+    final baseUrl = ref.watch(baseUrlProvider);
+    final ttsVoice = ref.watch(preferencesProvider.select((p) => p.selectedTtsVoice));
 
     return Scaffold(
       extendBodyBehindAppBar: true,
@@ -89,7 +92,7 @@ class IpaPracticePage extends ConsumerWidget {
 
                 // Content area
                 Expanded(
-                  child: _buildContent(context, ref, practiceState),
+                  child: _buildContent(context, ref, practiceState, baseUrl: baseUrl, ttsVoice: ttsVoice),
                 ),
               ],
             ),
@@ -99,7 +102,7 @@ class IpaPracticePage extends ConsumerWidget {
     );
   }
 
-  Widget _buildContent(BuildContext context, WidgetRef ref, IpaPracticeState state) {
+  Widget _buildContent(BuildContext context, WidgetRef ref, IpaPracticeState state, {required String baseUrl, String? ttsVoice}) {
     if (state.isLoading) {
       return const Center(
         child: Column(
@@ -201,6 +204,8 @@ class IpaPracticePage extends ConsumerWidget {
                 children: [
                   AudioPlayerButton(
                     audioUrl: sound.audioUrl,
+                    baseUrl: baseUrl,
+                    voice: ttsVoice,
                     iconSize: 20,
                   ),
                   const SizedBox(width: 8),

--- a/pronunciapa_client/lib/presentation/pages/models_page.dart
+++ b/pronunciapa_client/lib/presentation/pages/models_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/model_installer_provider.dart';
+import '../providers/preferences_provider.dart';
 import '../widgets/app_background.dart';
 
 /// Página de gestión de modelos
@@ -240,13 +241,13 @@ class _ModelsPageState extends ConsumerState<ModelsPage> {
                 ),
           ),
         ),
-        ...models.map((model) => _buildModelCard(model)),
+        ...models.map((model) => _buildModelCard(model, category: category)),
         const SizedBox(height: 8),
       ],
     );
   }
 
-  Widget _buildModelCard(ModelInfo model) {
+  Widget _buildModelCard(ModelInfo model, {String? category}) {
     final isInstalling = _installingModelId == model.id;
 
     return Card(
@@ -298,7 +299,7 @@ class _ModelsPageState extends ConsumerState<ModelsPage> {
               ),
           ],
         ),
-        trailing: _buildActionButton(model, isInstalling),
+        trailing: _buildActionButton(model, isInstalling, category: category),
         isThreeLine: true,
       ),
     );
@@ -331,8 +332,34 @@ class _ModelsPageState extends ConsumerState<ModelsPage> {
     }
   }
 
-  Widget? _buildActionButton(ModelInfo model, bool isInstalling) {
+  Widget? _buildActionButton(ModelInfo model, bool isInstalling, {String? category}) {
     if (model.isInstalled) {
+      // For TTS models, also show a "Use as voice" button
+      if (category == 'tts') {
+        final selectedVoice = ref.watch(preferencesProvider).selectedTtsVoice;
+        final isActive = selectedVoice == model.id;
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.check, color: Colors.green),
+            const SizedBox(width: 4),
+            Tooltip(
+              message: isActive ? 'Voz activa' : 'Usar esta voz',
+              child: IconButton(
+                icon: Icon(
+                  isActive ? Icons.star : Icons.star_border,
+                  color: isActive ? Colors.amber : Colors.grey,
+                ),
+                onPressed: () {
+                  ref.read(preferencesProvider.notifier).setTtsVoice(
+                    isActive ? null : model.id,
+                  );
+                },
+              ),
+            ),
+          ],
+        );
+      }
       return const Icon(Icons.check, color: Colors.green);
     }
 

--- a/pronunciapa_client/lib/presentation/pages/practice_detail_page.dart
+++ b/pronunciapa_client/lib/presentation/pages/practice_detail_page.dart
@@ -7,6 +7,7 @@ import '../theme/app_theme.dart';
 import '../widgets/app_background.dart';
 import '../widgets/diff_viewer_widget.dart';
 import '../widgets/feedback_level_selector.dart';
+import '../../domain/entities/feedback_result.dart';
 
 /// Practice detail page for a specific IPA sound
 class PracticeDetailPage extends ConsumerStatefulWidget {
@@ -96,13 +97,18 @@ class _PracticeDetailPageState extends ConsumerState<PracticeDetailPage> {
 
     try {
       final repository = ref.read(pronunciationRepositoryProvider);
-      final result = await repository.compare(
+      // Use getFeedback so LLM advice is always available, respecting the
+      // feedback level the user selected with FeedbackLevelSelector.
+      final feedbackResult = await repository.getFeedback(
         _recordedFilePath!,
         _selectedExample,
-        evaluationLevel: 'phonemic', // Default to phonemic for practice
-        mode: 'objective', // Default to objective mode
+        evaluationLevel: 'phonemic',
+        mode: 'objective',
         lang: widget.lang,
+        feedbackLevel: _feedbackLevel.name,
       );
+      final result = feedbackResult.compare;
+      final feedbackPayload = feedbackResult.feedback;
 
       if (mounted) {
         showDialog(
@@ -249,6 +255,38 @@ class _PracticeDetailPageState extends ConsumerState<PracticeDetailPage> {
                     ),
                   ],
                   const SizedBox(height: 8),
+                  // LLM Feedback — summary + advice
+                  const Divider(),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      const Icon(Icons.lightbulb_outline, size: 16, color: Colors.amber),
+                      const SizedBox(width: 6),
+                      const Text(
+                        'Retroalimentación IA',
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    feedbackPayload.summary,
+                    style: const TextStyle(fontSize: 14),
+                  ),
+                  if (feedbackPayload.adviceShort.isNotEmpty) ...[
+                    const SizedBox(height: 8),
+                    Container(
+                      padding: const EdgeInsets.all(10),
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).colorScheme.primaryContainer.withOpacity(0.3),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        feedbackPayload.adviceShort,
+                        style: const TextStyle(fontSize: 13, fontStyle: FontStyle.italic),
+                      ),
+                    ),
+                  ],
                 ],
               ),
             ),

--- a/pronunciapa_client/lib/presentation/pages/results_page.dart
+++ b/pronunciapa_client/lib/presentation/pages/results_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
+import '../providers/api_provider.dart' show FeedbackPayload;
 import '../theme/app_theme.dart';
 import '../widgets/app_background.dart';
+import 'drills_page.dart';
 
 /// Pantalla de resultados con diseño premium
 class ResultsPage extends ConsumerWidget {
@@ -10,15 +12,15 @@ class ResultsPage extends ConsumerWidget {
   final String targetIpa;
   final String observedIpa;
   final List<PhonemeResult> phonemes;
-  final String? feedback;
-  
+  final FeedbackPayload? feedbackPayload;
+
   const ResultsPage({
     super.key,
     required this.score,
     required this.targetIpa,
     required this.observedIpa,
     required this.phonemes,
-    this.feedback,
+    this.feedbackPayload,
   });
   
   @override
@@ -89,30 +91,56 @@ class ResultsPage extends ConsumerWidget {
                   ),
                   const SizedBox(height: 24),
 
-                  // Feedback Card
-                  if (feedback != null) ...[
+                  // Feedback Card — LLM summary + advice
+                  if (feedbackPayload != null) ...[
                     GlassCard(
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Row(
                             children: [
-                              Icon(
-                                Icons.lightbulb_outline,
-                                color: AppTheme.warning,
-                              ),
+                              Icon(Icons.lightbulb_outline, color: AppTheme.warning),
                               const SizedBox(width: 8),
-                              Text(
-                                'Sugerencias',
-                                style: theme.textTheme.titleLarge,
-                              ),
+                              Text('Sugerencias IA', style: theme.textTheme.titleLarge),
                             ],
                           ),
                           const SizedBox(height: 12),
-                          Text(
-                            feedback!,
-                            style: theme.textTheme.bodyLarge,
-                          ),
+                          Text(feedbackPayload!.summary, style: theme.textTheme.bodyLarge),
+                          if (feedbackPayload!.adviceShort.isNotEmpty) ...[
+                            const SizedBox(height: 12),
+                            Container(
+                              padding: const EdgeInsets.all(12),
+                              decoration: BoxDecoration(
+                                color: theme.colorScheme.primaryContainer.withOpacity(0.3),
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              child: Text(
+                                feedbackPayload!.adviceShort,
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  fontStyle: FontStyle.italic,
+                                ),
+                              ),
+                            ),
+                          ],
+                          if (feedbackPayload!.warnings != null &&
+                              feedbackPayload!.warnings!.isNotEmpty) ...[
+                            const SizedBox(height: 12),
+                            ...feedbackPayload!.warnings!.map(
+                              (w) => Row(
+                                children: [
+                                  Icon(Icons.warning_amber_outlined,
+                                      size: 16, color: AppTheme.warning),
+                                  const SizedBox(width: 6),
+                                  Expanded(
+                                    child: Text(w,
+                                        style: theme.textTheme.bodySmall?.copyWith(
+                                          color: AppTheme.warning,
+                                        )),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
                         ],
                       ),
                     ),
@@ -132,23 +160,36 @@ class ResultsPage extends ConsumerWidget {
                           ),
                         ),
                       ),
-                      const SizedBox(width: 16),
-                      Expanded(
-                        child: GradientButton(
-                          onPressed: () {
-                            Navigator.pop(context);
-                            // TODO: Navigate to next exercise
-                          },
-                          child: const Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text('Siguiente', style: TextStyle(color: Colors.white)),
-                              SizedBox(width: 8),
-                              Icon(Icons.arrow_forward, color: Colors.white),
-                            ],
+                      if (feedbackPayload != null) ...[
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: GradientButton(
+                            onPressed: () {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (_) => DrillsPage(
+                                    drills: feedbackPayload!.drills,
+                                    targetIpa: targetIpa,
+                                    observedIpa: observedIpa,
+                                    summary: feedbackPayload!.adviceLong.isNotEmpty
+                                        ? feedbackPayload!.adviceLong
+                                        : feedbackPayload!.summary,
+                                  ),
+                                ),
+                              );
+                            },
+                            child: const Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text('Ejercicios', style: TextStyle(color: Colors.white)),
+                                SizedBox(width: 8),
+                                Icon(Icons.arrow_forward, color: Colors.white),
+                              ],
+                            ),
                           ),
                         ),
-                      ),
+                      ],
                     ],
                   ),
                 ],

--- a/pronunciapa_client/lib/presentation/pages/sound_lesson_page.dart
+++ b/pronunciapa_client/lib/presentation/pages/sound_lesson_page.dart
@@ -1,7 +1,9 @@
+import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/ipa_learning_provider.dart';
 import '../providers/progress_provider.dart';
+import '../providers/repository_provider.dart';
 import '../theme/app_theme.dart';
 import '../widgets/app_background.dart';
 import '../widgets/audio_player_button.dart';
@@ -30,6 +32,8 @@ class _SoundLessonPageState extends ConsumerState<SoundLessonPage>
   List<Drill> _drills = [];
   bool _isLoading = true;
   int _sessionPracticeCount = 0;
+  // Single player for minimal-pair audio so old playback stops on new tap.
+  final AudioPlayer _pairPlayer = AudioPlayer();
 
   @override
   void initState() {
@@ -74,9 +78,18 @@ class _SoundLessonPageState extends ConsumerState<SoundLessonPage>
     );
   }
 
+  Future<void> _playPairAudio(String? audioUrl) async {
+    if (audioUrl == null) return;
+    final baseUrl = ref.read(baseUrlProvider);
+    final fullUrl = audioUrl.startsWith('http') ? audioUrl : '$baseUrl$audioUrl';
+    await _pairPlayer.stop();
+    await _pairPlayer.play(UrlSource(fullUrl));
+  }
+
   @override
   void dispose() {
     _tabController.dispose();
+    _pairPlayer.dispose();
     // Record practice time
     if (_sessionPracticeCount > 0) {
       ref.read(progressProvider.notifier).addPracticeTime(1);
@@ -522,12 +535,9 @@ class _SoundLessonPageState extends ConsumerState<SoundLessonPage>
         children: [
           Expanded(
             child: OutlinedButton.icon(
-              icon: AudioPlayerButton(
-                audioUrl: pair.audio1Url,
-                iconSize: 18,
-              ),
+              icon: const Icon(Icons.volume_up, size: 18),
               label: Text(pair.word1),
-              onPressed: () {},
+              onPressed: () => _playPairAudio(pair.audio1Url),
             ),
           ),
           const Padding(
@@ -536,12 +546,9 @@ class _SoundLessonPageState extends ConsumerState<SoundLessonPage>
           ),
           Expanded(
             child: OutlinedButton.icon(
-              icon: AudioPlayerButton(
-                audioUrl: pair.audio2Url,
-                iconSize: 18,
-              ),
+              icon: const Icon(Icons.volume_up, size: 18),
               label: Text(pair.word2),
-              onPressed: () {},
+              onPressed: () => _playPairAudio(pair.audio2Url),
             ),
           ),
         ],

--- a/pronunciapa_client/lib/presentation/providers/api_provider.dart
+++ b/pronunciapa_client/lib/presentation/providers/api_provider.dart
@@ -7,111 +7,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/debug/app_logger.dart';
 import '../../core/debug/debug_http_client.dart';
 import '../../core/debug/debug_log_store.dart';
+// Canonical domain types — eliminates duplicate class definitions.
+import '../../domain/entities/feedback_result.dart';
+import '../../domain/entities/transcription_result.dart';
 
-class EditOp {
-  final String op;
-  final String? ref;
-  final String? hyp;
-
-  EditOp({required this.op, this.ref, this.hyp});
-
-  factory EditOp.fromJson(Map<String, dynamic> json) {
-    return EditOp(
-      op: json['op'] as String,
-      ref: json['ref'] as String?,
-      hyp: json['hyp'] as String?,
-    );
-  }
-}
-
-class TranscriptionResult {
-  final String ipa;
-  final double? score; // 0-100 scale (higher is better)
-  final double? per; // Phone Error Rate 0.0-1.0 (lower is better)
-  final List<List<String?>>? alignment;
-  final List<EditOp>? ops; // Edit operations from backend
-  final List<String>? tokens; // Observed IPA tokens
-  final String? mode; // casual, objective, phonetic
-  final String? evaluationLevel; // phonemic, phonetic
-  final String? targetIpa; // Reference IPA
-  final Map<String, dynamic>? meta;
-
-  TranscriptionResult({
-    required this.ipa,
-    this.score,
-    this.per,
-    this.alignment,
-    this.ops,
-    this.tokens,
-    this.mode,
-    this.evaluationLevel,
-    this.targetIpa,
-    this.meta,
-  });
-}
-
-class FeedbackDrill {
-  final String type;
-  final String text;
-
-  FeedbackDrill({required this.type, required this.text});
-
-  factory FeedbackDrill.fromJson(Map<String, dynamic> json) {
-    return FeedbackDrill(
-      type: json['type'] as String,
-      text: json['text'] as String,
-    );
-  }
-}
-
-class FeedbackPayload {
-  final String summary;
-  final String adviceShort;
-  final String adviceLong;
-  final List<FeedbackDrill> drills;
-  final String? feedbackLevel;
-  final String? tone;
-  final String? confidence;
-  final List<String>? warnings;
-
-  FeedbackPayload({
-    required this.summary,
-    required this.adviceShort,
-    required this.adviceLong,
-    required this.drills,
-    this.feedbackLevel,
-    this.tone,
-    this.confidence,
-    this.warnings,
-  });
-
-  factory FeedbackPayload.fromJson(Map<String, dynamic> json) {
-    return FeedbackPayload(
-      summary: json['summary'] as String,
-      adviceShort: json['advice_short'] as String,
-      adviceLong: json['advice_long'] as String,
-      drills: (json['drills'] as List<dynamic>)
-          .map((d) => FeedbackDrill.fromJson(d as Map<String, dynamic>))
-          .toList(),
-      feedbackLevel: json['feedback_level'] as String?,
-      tone: json['tone'] as String?,
-      confidence: json['confidence'] as String?,
-      warnings: (json['warnings'] as List<dynamic>?)?.cast<String>(),
-    );
-  }
-}
-
-class FeedbackResult {
-  final TranscriptionResult compare;
-  final FeedbackPayload feedback;
-  final Map<String, dynamic> report;
-
-  FeedbackResult({
-    required this.compare,
-    required this.feedback,
-    required this.report,
-  });
-}
+// Re-export so existing files that import api_provider keep compiling.
+export '../../domain/entities/feedback_result.dart'
+    show EditOp, FeedbackDrill, FeedbackPayload, FeedbackResult;
+export '../../domain/entities/transcription_result.dart' show TranscriptionResult;
 
 class PronunciaApiService {
   static const Duration _requestTimeout = Duration(seconds: 60);
@@ -563,22 +466,84 @@ class ApiNotifier extends StateNotifier<ApiState> {
       );
     }
   }
-  /// Re-process the last recording with full analysis (quality gates, adaptation).
+  /// Full analysis with LLM feedback via /v1/feedback.
+  Future<void> processFeedback({
+    String? path,
+    String? referenceText,
+    String? lang,
+    String? evaluationLevel,
+    String? mode,
+    String? feedbackLevel,
+  }) async {
+    final audioPath = path ?? state.lastAudioPath;
+    final ref = referenceText ?? state.lastReferenceText;
+    if (audioPath == null || ref == null || ref.isEmpty) return;
+
+    state = state.copyWith(
+      isLoading: true,
+      error: null,
+      clearResult: true,
+      clearFeedback: true,
+    );
+    try {
+      final result = await _service.feedback(
+        audioPath,
+        ref,
+        lang: lang ?? 'es',
+        evaluationLevel: evaluationLevel,
+        mode: mode,
+        feedbackLevel: feedbackLevel,
+      );
+      _logAudioChainToOverlay(result.compare.meta);
+      state = state.copyWith(
+        isLoading: false,
+        result: result.compare,
+        feedbackResult: result,
+        lastAudioPath: audioPath,
+        lastReferenceText: ref,
+        isQuickResult: false,
+      );
+    } on TimeoutException catch (e) {
+      AppLogger.w('ApiNotifier', 'Timeout error: $e');
+      state = state.copyWith(
+        isLoading: false,
+        error: 'Timeout: El servidor tardó demasiado en responder.',
+        clearResult: true,
+        clearFeedback: true,
+      );
+    } on SocketException catch (e) {
+      AppLogger.w('ApiNotifier', 'Socket error: $e');
+      state = state.copyWith(
+        isLoading: false,
+        error: 'Error de red: No se pudo conectar a ${_service.baseUrl}. ¿Está el backend encendido?',
+        clearResult: true,
+        clearFeedback: true,
+      );
+    } catch (e, stack) {
+      AppLogger.e('ApiNotifier', 'Unhandled error: $e', error: e, stackTrace: stack);
+      String msg = e.toString();
+      if (msg.startsWith('Exception: ')) msg = msg.substring(11);
+      state = state.copyWith(
+        isLoading: false,
+        error: msg,
+        clearResult: true,
+        clearFeedback: true,
+      );
+    }
+  }
+
+  /// Re-process the last recording with full LLM feedback analysis.
   Future<void> reprocessFull({
     String? lang,
     String? evaluationLevel,
     String? mode,
+    String? feedbackLevel,
   }) async {
-    final path = state.lastAudioPath;
-    final ref = state.lastReferenceText;
-    if (path == null || ref == null || ref.isEmpty) return;
-    await processAudio(
-      path,
-      referenceText: ref,
+    await processFeedback(
       lang: lang,
       evaluationLevel: evaluationLevel,
       mode: mode,
-      quick: false,
+      feedbackLevel: feedbackLevel,
     );
   }
 }

--- a/pronunciapa_client/lib/presentation/providers/ipa_learning_provider.dart
+++ b/pronunciapa_client/lib/presentation/providers/ipa_learning_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
+import 'repository_provider.dart';
 
 /// Model for IPA learning module
 class IpaModule {
@@ -157,9 +158,9 @@ class IpaLearningState {
 
 /// Provider for IPA learning content
 class IpaLearningNotifier extends StateNotifier<IpaLearningState> {
-  static const String _baseUrl = 'http://127.0.0.1:8000';
+  final String _baseUrl;
 
-  IpaLearningNotifier() : super(IpaLearningState()) {
+  IpaLearningNotifier(this._baseUrl) : super(IpaLearningState()) {
     loadContent('en'); // Default to English
   }
 
@@ -230,5 +231,6 @@ class IpaLearningNotifier extends StateNotifier<IpaLearningState> {
 
 final ipaLearningProvider =
     StateNotifierProvider<IpaLearningNotifier, IpaLearningState>((ref) {
-  return IpaLearningNotifier();
+  final baseUrl = ref.watch(baseUrlProvider);
+  return IpaLearningNotifier(baseUrl);
 });

--- a/pronunciapa_client/lib/presentation/providers/ipa_practice_provider.dart
+++ b/pronunciapa_client/lib/presentation/providers/ipa_practice_provider.dart
@@ -93,7 +93,9 @@ class IpaPracticeState {
 
 /// Provider for IPA practice state
 class IpaPracticeNotifier extends StateNotifier<IpaPracticeState> {
-  IpaPracticeNotifier(PronunciationRepository repository) : super(IpaPracticeState()) {
+  final String _baseUrl;
+
+  IpaPracticeNotifier(PronunciationRepository repository, this._baseUrl) : super(IpaPracticeState()) {
     loadSounds();
   }
 
@@ -134,9 +136,7 @@ class IpaPracticeNotifier extends StateNotifier<IpaPracticeState> {
   }
 
   Future<List<IpaSound>> _fetchIpaSounds(String lang) async {
-    // Usar localhost para desarrollo
-    const baseUrl = 'http://127.0.0.1:8000';
-    final url = Uri.parse('$baseUrl/api/ipa-sounds?lang=$lang');
+    final url = Uri.parse('$_baseUrl/api/ipa-sounds?lang=$lang');
     
     final response = await http.get(url).timeout(
       const Duration(seconds: 5),
@@ -277,5 +277,6 @@ class IpaPracticeNotifier extends StateNotifier<IpaPracticeState> {
 /// Provider instance
 final ipaPracticeProvider = StateNotifierProvider<IpaPracticeNotifier, IpaPracticeState>((ref) {
   final repository = ref.watch(pronunciationRepositoryProvider);
-  return IpaPracticeNotifier(repository);
+  final baseUrl = ref.watch(baseUrlProvider);
+  return IpaPracticeNotifier(repository, baseUrl);
 });

--- a/pronunciapa_client/lib/presentation/providers/lesson_plan_provider.dart
+++ b/pronunciapa_client/lib/presentation/providers/lesson_plan_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'repository_provider.dart';
+import 'preferences_provider.dart';
 
 // ── Domain models ─────────────────────────────────────────────────────────────
 
@@ -189,14 +190,24 @@ class LessonPlanNotifier extends StateNotifier<LessonPlanState> {
   }
 
   void setLang(String lang) {
+    if (_lang == lang) return;
     _lang = lang;
     state = const LessonPlanState();
+    loadAll();
   }
 }
 
 // ── Provider ──────────────────────────────────────────────────────────────────
 
 final lessonPlanProvider =
-    StateNotifierProvider<LessonPlanNotifier, LessonPlanState>(
-  (ref) => LessonPlanNotifier(ref),
-);
+    StateNotifierProvider<LessonPlanNotifier, LessonPlanState>((ref) {
+  final notifier = LessonPlanNotifier(ref);
+  // Sync language from preferences. fireImmediately triggers on first build
+  // so the notifier always uses the persisted lang on startup.
+  ref.listen(
+    preferencesProvider.select((p) => p.lang),
+    (_, lang) => notifier.setLang(lang),
+    fireImmediately: true,
+  );
+  return notifier;
+});

--- a/pronunciapa_client/lib/presentation/providers/preferences_provider.dart
+++ b/pronunciapa_client/lib/presentation/providers/preferences_provider.dart
@@ -12,6 +12,8 @@ class UserPreferences {
   final bool darkMode;
   final bool hapticFeedback;
   final bool audioFeedback;
+  /// Model ID to pass as ?voice= to /api/tts/speak. null = server default.
+  final String? selectedTtsVoice;
 
   const UserPreferences({
     this.lang = 'en',
@@ -21,6 +23,7 @@ class UserPreferences {
     this.darkMode = false,
     this.hapticFeedback = true,
     this.audioFeedback = true,
+    this.selectedTtsVoice,
   });
 
   UserPreferences copyWith({
@@ -31,6 +34,8 @@ class UserPreferences {
     bool? darkMode,
     bool? hapticFeedback,
     bool? audioFeedback,
+    String? selectedTtsVoice,
+    bool clearTtsVoice = false,
   }) {
     return UserPreferences(
       lang: lang ?? this.lang,
@@ -40,6 +45,7 @@ class UserPreferences {
       darkMode: darkMode ?? this.darkMode,
       hapticFeedback: hapticFeedback ?? this.hapticFeedback,
       audioFeedback: audioFeedback ?? this.audioFeedback,
+      selectedTtsVoice: clearTtsVoice ? null : (selectedTtsVoice ?? this.selectedTtsVoice),
     );
   }
 
@@ -51,6 +57,7 @@ class UserPreferences {
         'darkMode': darkMode,
         'hapticFeedback': hapticFeedback,
         'audioFeedback': audioFeedback,
+        if (selectedTtsVoice != null) 'selectedTtsVoice': selectedTtsVoice,
       };
 
   factory UserPreferences.fromJson(Map<String, dynamic> json) {
@@ -65,6 +72,7 @@ class UserPreferences {
       darkMode: json['darkMode'] ?? false,
       hapticFeedback: json['hapticFeedback'] ?? true,
       audioFeedback: json['audioFeedback'] ?? true,
+      selectedTtsVoice: json['selectedTtsVoice'] as String?,
     );
   }
 
@@ -172,6 +180,13 @@ class PreferencesNotifier extends StateNotifier<UserPreferences> {
   void toggleFeedbackLevel() {
     final newLevel = state.feedbackLevel == 'casual' ? 'precise' : 'casual';
     setFeedbackLevel(newLevel);
+  }
+
+  void setTtsVoice(String? voiceId) {
+    state = voiceId == null
+        ? state.copyWith(clearTtsVoice: true)
+        : state.copyWith(selectedTtsVoice: voiceId);
+    _save();
   }
 }
 

--- a/pronunciapa_client/lib/presentation/widgets/audio_player_button.dart
+++ b/pronunciapa_client/lib/presentation/widgets/audio_player_button.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:audioplayers/audioplayers.dart';
 
-/// Button widget that plays audio from a URL
+/// Button widget that plays audio from a URL.
+/// Pass [voice] to append `?voice=<id>` to TTS endpoint URLs.
 class AudioPlayerButton extends StatefulWidget {
   final String? audioUrl;
   final String baseUrl;
+  final String? voice;
   final IconData playIcon;
   final IconData loadingIcon;
   final double iconSize;
@@ -13,6 +15,7 @@ class AudioPlayerButton extends StatefulWidget {
     super.key,
     this.audioUrl,
     this.baseUrl = 'http://127.0.0.1:8000',
+    this.voice,
     this.playIcon = Icons.volume_up,
     this.loadingIcon = Icons.hourglass_empty,
     this.iconSize = 24.0,
@@ -66,10 +69,14 @@ class _AudioPlayerButtonState extends State<AudioPlayerButton> {
         return;
       }
 
-      // Build full URL
-      final fullUrl = widget.audioUrl!.startsWith('http')
+      // Build full URL, appending voice param for TTS endpoints if selected.
+      String fullUrl = widget.audioUrl!.startsWith('http')
           ? widget.audioUrl!
           : '${widget.baseUrl}${widget.audioUrl}';
+      if (widget.voice != null && fullUrl.contains('/api/tts/speak')) {
+        final separator = fullUrl.contains('?') ? '&' : '?';
+        fullUrl = '$fullUrl${separator}voice=${Uri.encodeQueryComponent(widget.voice!)}';
+      }
 
       // Play audio from URL
       await _audioPlayer.play(UrlSource(fullUrl));

--- a/pronunciapa_client/lib/presentation/widgets/audio_player_button.dart
+++ b/pronunciapa_client/lib/presentation/widgets/audio_player_button.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:audioplayers/audioplayers.dart';
 
@@ -27,15 +28,16 @@ class AudioPlayerButton extends StatefulWidget {
 
 class _AudioPlayerButtonState extends State<AudioPlayerButton> {
   final AudioPlayer _audioPlayer = AudioPlayer();
+  StreamSubscription? _stateSubscription;
   bool _isPlaying = false;
   bool _isLoading = false;
 
   @override
   void initState() {
     super.initState();
-    
-    // Listen to player state changes
-    _audioPlayer.onPlayerStateChanged.listen((state) {
+
+    // Listen to player state changes; store subscription to cancel on dispose.
+    _stateSubscription = _audioPlayer.onPlayerStateChanged.listen((state) {
       if (mounted) {
         setState(() {
           _isPlaying = state == PlayerState.playing;
@@ -47,6 +49,7 @@ class _AudioPlayerButtonState extends State<AudioPlayerButton> {
 
   @override
   void dispose() {
+    _stateSubscription?.cancel();
     _audioPlayer.dispose();
     super.dispose();
   }


### PR DESCRIPTION
## Summary
This PR refactors the codebase to improve architecture and UX by:
1. Moving domain entity classes (`TranscriptionResult`, `FeedbackResult`, `EditOp`, `FeedbackDrill`, `FeedbackPayload`) from `api_provider.dart` to dedicated files in `domain/entities/`
2. Replacing top-level navigation buttons with a Material 3 `NavigationBar` in a new `MainShell` widget
3. Adding LLM feedback integration throughout the app with a new `DrillsPage` for practice exercises
4. Improving audio playback and TTS voice selection

## Key Changes

### Architecture & Domain Layer
- **Extracted domain entities** to `domain/entities/transcription_result.dart` and `domain/entities/feedback_result.dart` to eliminate duplication and improve separation of concerns
- **Re-exported entities** from `api_provider.dart` for backward compatibility with existing imports
- **Added `processFeedback()` method** to `ApiNotifier` for dedicated LLM feedback endpoint (`/v1/feedback`)
- **Refactored `reprocessFull()`** to use the new `processFeedback()` method with `feedbackLevel` parameter

### Navigation & UI
- **Replaced top-level AppBar buttons** (Learn, Practice, Progress, Settings) with a persistent `NavigationBar` in new `MainShell` widget
- **Preserved page state** using `IndexedStack` so navigation between tabs doesn't reset UI state
- **Removed inline navigation** from `HomePage` (removed `SettingsPage`, `IpaLearnPage`, `IpaPracticePage`, `ProgressRoadmapPage` imports and buttons)
- **Simplified `HomePage`** by removing unused `_buildResultCard()` and `_buildLegacyAlignment()` methods

### LLM Feedback Integration
- **Updated `ResultsPage`** to accept `FeedbackPayload` instead of simple string feedback
- **Added rich feedback display** with summary, advice, and warnings in results
- **Created `DrillsPage` navigation** from results when LLM drills are available
- **Enhanced `PracticeDetailPage`** to call `getFeedback()` and display LLM feedback summary + advice
- **Updated `practice_detail_page.dart`** to show AI feedback with lightbulb icon and styled advice container

### Audio & TTS
- **Added `voice` parameter** to `AudioPlayerButton` for TTS voice selection via `?voice=<id>` query param
- **Improved audio player lifecycle** in `AudioPlayerButton` with proper `StreamSubscription` cleanup
- **Added dedicated `_pairPlayer`** in `SoundLessonPage` for minimal-pair audio with stop-on-new-tap behavior
- **Added TTS voice selection UI** in `ModelsPage` with star icon to set active voice

### Preferences & State Management
- **Added `selectedTtsVoice` field** to `UserPreferences` for persisting TTS voice choice
- **Synced language preference** in `LessonPlanNotifier` with `fireImmediately: true` to load correct content on startup
- **Updated theme mode** to read from `preferencesProvider.darkMode` instead of separate `themeModeProvider`
- **Fixed `IpaPracticeNotifier` and `IpaLearningNotifier`** to use injected `baseUrl` from `repository_provider` instead of hardcoded localhost

### Bug Fixes & Improvements
- **Fixed `ResultsPage` type casting** for `targetIpa` from metadata
- **Improved error handling** in `ApiNotifier` with proper timeout and socket exception messages
- **Added `feedbackLevel` parameter** throughout the feedback flow (home page, practice detail, reprocess)
- **Cleaned up unused imports** and removed dead code from `home_page.dart`

## Notable Implementation Details
- Domain entities now follow clean architecture principles with dedicated files
- Navigation state is preserved across tab switches via `IndexedStack`
- LLM feedback is always fetched when available, respecting user-selected feedback level
- Audio playback properly manages resources with subscription cleanup
- TTS voice selection is persisted

https://claude.ai/code/session_013nixwunHTi1nCZwwZeVuFy