### PR TITLE
Add default language fallback and fix code style issues

### DIFF
--- a/ipa_core/backends/allosaurus_backend.py
+++ b/ipa_core/backends/allosaurus_backend.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from pathlib import Path
 from typing import Any, Optional, TYPE_CHECKING
 
@@ -136,7 +137,6 @@ class AllosaurusBackend(BasePlugin):
         # ── Urálicas ──────────────────────────────────────────────────────────
         "fi": "fin",    # Finés
         "hu": "hun",    # Húngaro
-        "et": "est",    # Estonio (también urálica)
         "kpv": "kpv",   # Komi-Zyryan
         "koi": "koi",   # Komi-Permyak
         "mhr": "mhr",   # Mari del este
@@ -209,7 +209,6 @@ class AllosaurusBackend(BasePlugin):
         "sm": "smo",    # Samoano
         "to": "ton",    # Tongano
         "haw": "haw",   # Hawaiano
-        "mg": "mlg",    # Malgache (también Austronesia)
         "ceb": "ceb",   # Cebuano
         "ilo": "ilo",   # Ilocano
         "war": "war",   # Waray-Waray
@@ -218,7 +217,6 @@ class AllosaurusBackend(BasePlugin):
         "lo": "lao",    # Laosiano
         "km": "khm",    # Jemer
         "vi": "vie",    # Vietnamita
-        "mn": "khk",    # Mongol
         # ── Caucásicas ────────────────────────────────────────────────────────
         "ka": "kat",    # Georgiano
         "ab": "abk",    # Abjasio
@@ -229,9 +227,6 @@ class AllosaurusBackend(BasePlugin):
         "inh": "inh",   # Ingush
         # ── Lenguas de signos y otras ─────────────────────────────────────────
         "eu": "eus",    # Euskera (aislada)
-        "ka": "kat",    # Georgiano
-        "mn": "khk",    # Mongol
-        "hy": "hye",    # Armenio (también IE pero incluido aquí para agrupación)
         # ── Lenguas indígenas americanas ──────────────────────────────────────
         "qu": "que",    # Quechua
         "ay": "aym",    # Aimara
@@ -307,7 +302,15 @@ class AllosaurusBackend(BasePlugin):
         resolved = lang if lang is not None else self._lang
         if resolved:
             return self._LANG_MAP.get(resolved, resolved)
-        return None
+        # Sin idioma → inventario universal produce fonemas de otros idiomas.
+        # Usar fallback configurable para restringir el inventario.
+        default = os.getenv("PRONUNCIAPA_DEFAULT_LANG", "es")
+        logger.warning(
+            "No se especificó idioma para Allosaurus; usando fallback '%s'. "
+            "Configure PRONUNCIAPA_DEFAULT_LANG o pase lang= explícitamente.",
+            default,
+        )
+        return self._LANG_MAP.get(default, default)
     
     async def transcribe(
         self,

--- a/ipa_core/compare/tests/test_levenshtein.py
+++ b/ipa_core/compare/tests/test_levenshtein.py
@@ -18,15 +18,15 @@ class TestLevenshteinComparator(ComparatorContract):
         result = await cmp.compare(["a", "b"], ["a", "b"])
         assert result["per"] == 0.0
 
-        @pytest.mark.asyncio
-        async def test_compare_counts_ops(self) -> None:
-            # Without articulatory weights, PER = 2/3 (1 substitution + 1 insertion)
-            cmp_basic = LevenshteinComparator(use_articulatory=False)
-            result_basic = await cmp_basic.compare(["a", "b", "c"], ["a", "x", "c", "d"])
-            assert pytest.approx(result_basic["per"]) == 2 / 3
-    
-            # With articulatory weights, PER < 2/3 because b->x substitution is weighted
-            cmp = LevenshteinComparator(use_articulatory=True)
-            result = await cmp.compare(["a", "b", "c"], ["a", "x", "c", "d"])
-            assert 0.0 < result["per"] < 2 / 3
+    @pytest.mark.asyncio
+    async def test_compare_counts_ops(self) -> None:
+        # Without articulatory weights, PER = 2/3 (1 substitution + 1 insertion)
+        cmp_basic = LevenshteinComparator(use_articulatory=False)
+        result_basic = await cmp_basic.compare(["a", "b", "c"], ["a", "x", "c", "d"])
+        assert pytest.approx(result_basic["per"]) == 2 / 3
+
+        # With articulatory weights, PER < 2/3 because b->x substitution is weighted
+        cmp = LevenshteinComparator(use_articulatory=True)
+        result = await cmp.compare(["a", "b", "c"], ["a", "x", "c", "d"])
+        assert 0.0 < result["per"] < 2 / 3
     

--- a/ipa_core/llm/llama_cpp.py
+++ b/ipa_core/llm/llama_cpp.py
@@ -106,6 +106,7 @@ def _binary_exists(binary: str) -> bool:
 def _write_prompt(prompt: str) -> Path:
     tmp = tempfile.NamedTemporaryFile(prefix="pronunciapa_llm_", suffix=".txt", delete=False)
     path = Path(tmp.name)
+    tmp.close()
     path.write_text(prompt, encoding="utf-8")
     return path
 

--- a/ipa_core/pipeline/runner.py
+++ b/ipa_core/pipeline/runner.py
@@ -16,6 +16,8 @@ Entrypoints
 """
 from __future__ import annotations
 
+import logging
+import os
 from typing import Any, Optional
 
 from ipa_core.errors import ValidationError
@@ -23,7 +25,7 @@ from ipa_core.ports.asr import ASRBackend
 from ipa_core.ports.compare import Comparator
 from ipa_core.ports.preprocess import Preprocessor
 from ipa_core.ports.textref import TextRefProvider
-from ipa_core.types import AudioInput, CompareResult, CompareWeights, Token
+from ipa_core.types import ASRResult, AudioInput, CompareResult, CompareWeights, PreprocessorResult, Token
 from ipa_core.phonology.representation import (
     PhonologicalRepresentation,
     RepresentationLevel,
@@ -34,6 +36,18 @@ from ipa_core.pipeline.ipa_cleaning import clean_asr_tokens, clean_textref_token
 from ipa_core.compare.compare import compare_representations
 from ipa_core.compare.oov_handler import OOVHandler
 from ipa_core.ports.oov import OOVHandlerPort
+
+logger = logging.getLogger(__name__)
+
+
+def _default_lang() -> str:
+    """Return the configured default language for TextRef when lang is None.
+
+    Uses PRONUNCIAPA_DEFAULT_LANG env var, falling back to "es" (Spanish).
+    """
+    default = os.getenv("PRONUNCIAPA_DEFAULT_LANG", "es")
+    logger.debug("lang no especificado; usando default '%s' para TextRef", default)
+    return default
 
 
 # Issues que impiden llamar al ASR — el audio no tiene información fonética útil.
@@ -118,11 +132,11 @@ async def execute_pipeline(
     pre_audio_res = await pre.process_audio(audio)
     processed_audio = pre_audio_res.get("audio", audio)
 
-    # Bloquear temprano si la calidad impide cualquier reconocimiento útil.
-    # Esto da al usuario feedback accionable en lugar de un error genérico de ASR.
-    _check_quality_gate(pre_audio_res)
-
     try:
+        # Bloquear temprano si la calidad impide cualquier reconocimiento útil.
+        # Esto da al usuario feedback accionable en lugar de un error genérico de ASR.
+        _check_quality_gate(pre_audio_res)
+
         # 2. ASR → tokens limpios → normalización → representación fonética
         asr_result = await asr.transcribe(processed_audio, lang=lang)
         raw_asr_tokens = asr_result.get("tokens")
@@ -144,7 +158,8 @@ async def execute_pipeline(
         observed_phonetic = PhonologicalRepresentation.phonetic("".join(asr_tokens))
 
         # 3. TextRef → tokens limpios → normalización → representación fonémica
-        tr_result = await textref.to_ipa(text, lang=lang or "")
+        effective_lang = lang or _default_lang()
+        tr_result = await textref.to_ipa(text, lang=effective_lang)
         raw_ref_tokens = tr_result.get("tokens", [])
         cleaned_ref = clean_textref_tokens(
             raw_ref_tokens,
@@ -262,10 +277,10 @@ async def run_pipeline(
     pre_audio_res = await pre.process_audio(audio)
     processed_audio = pre_audio_res.get("audio", audio)
 
-    # Bloquear temprano si la calidad impide el reconocimiento (feedback accionable).
-    _check_quality_gate(pre_audio_res)
-
     try:
+        # Bloquear temprano si la calidad impide el reconocimiento (feedback accionable).
+        _check_quality_gate(pre_audio_res)
+
         # 2. Transcripción ASR
         asr_result = await asr.transcribe(processed_audio, lang=lang)
 
@@ -276,7 +291,8 @@ async def run_pipeline(
             raise _quality_enriched_error(pre_audio_res, "ASR no devolvió tokens IPA")
 
         # 4. Obtención, limpieza y normalización de referencia
-        tr_result = await textref.to_ipa(text, lang=lang or "")
+        effective_lang = lang or _default_lang()
+        tr_result = await textref.to_ipa(text, lang=effective_lang)
         ref_tokens_raw = clean_textref_tokens(tr_result.get("tokens", []), lang=lang, preserve_allophones=False)
         ref_pre_res = await pre.normalize_tokens(ref_tokens_raw)
         ref_tokens = ref_pre_res.get("tokens", [])

--- a/ipa_core/plugins/registry.py
+++ b/ipa_core/plugins/registry.py
@@ -294,7 +294,7 @@ def resolve_asr(name: str, params: Optional[Dict[str, Any]] = None, *, strict_mo
     except (KeyError, NotReadyError) as e:
         if strict_mode:
             raise
-            logger.warning(f" ASR backend '{name}' no disponible ({e}). Usando StubASR como fallback.")
+        logger.warning(f" ASR backend '{name}' no disponible ({e}). Usando StubASR como fallback.")
         return resolve("asr", "stub", params)
 
 
@@ -308,7 +308,7 @@ def resolve_textref(name: str, params: Optional[Dict[str, Any]] = None, *, stric
     except (KeyError, NotReadyError) as e:
         if strict_mode:
             raise
-            logger.warning(f" TextRef '{name}' no disponible ({e}). Usando GraphemeTextRef como fallback.")
+        logger.warning(f" TextRef '{name}' no disponible ({e}). Usando GraphemeTextRef como fallback.")
         return resolve("textref", "grapheme", params)
 
 

--- a/ipa_server/routers/pipeline.py
+++ b/ipa_server/routers/pipeline.py
@@ -400,7 +400,7 @@ async def compare(
             )
             if not _asr_related:
                 raise  # TextRef / config error → keep 400
-                logger.warning("compare: pipeline audio error — respuesta no-speech: %s", _msg)
+            logger.warning("compare: pipeline audio error — respuesta no-speech: %s", _msg)
             try:
                 _tr = await kernel.textref.to_ipa(text, lang=lang_resolved)
                 _ref_tokens = clean_textref_tokens(


### PR DESCRIPTION
## Summary
This PR introduces a configurable default language fallback mechanism via the `PRONUNCIAPA_DEFAULT_LANG` environment variable and fixes several code style and logic issues across the codebase.

## Key Changes

- **Default Language Fallback**: Added `_default_lang()` function in `runner.py` that uses the `PRONUNCIAPA_DEFAULT_LANG` environment variable (defaulting to "es") when no language is specified. This is now used in both `execute_pipeline()` and `run_pipeline()` when calling TextRef.

- **Allosaurus Backend Fallback**: Updated `AllosaurusBackend._resolve_lang()` to use the same default language fallback instead of returning `None`, with appropriate warning logging.

- **Quality Gate Error Handling**: Moved `_check_quality_gate()` calls inside try-except blocks in both pipeline functions to ensure proper error handling and enrichment.

- **Code Style Fixes**:
  - Fixed indentation in `ipa_core/plugins/registry.py` for logger.warning statements in `resolve_asr()` and `resolve_textref()` (lines were incorrectly indented after raise statements)
  - Fixed indentation in `ipa_server/routers/pipeline.py` for logger.warning in the `compare()` function
  - Fixed test method indentation in `test_levenshtein.py` (moved `test_compare_counts_ops` to proper class-level indentation)

- **Resource Management**: Added `tmp.close()` in `llama_cpp.py` to properly close the temporary file before writing to it.

- **Language Mapping Cleanup**: Removed duplicate language mappings in `AllosaurusBackend` (Estonian, Malagasy, Mongolian, Georgian, Armenian).

- **Type Imports**: Added `ASRResult` and `PreprocessorResult` to imports in `runner.py` for better type hints.

## Implementation Details

The default language mechanism ensures consistent behavior across the pipeline when language is not explicitly specified, improving user experience by providing actionable feedback rather than generic errors. The environment variable approach allows deployment-time configuration without code changes.

https://claude.ai/code/session_01WyJJcXDsoBnJL43HRPr37Z